### PR TITLE
fix: 修复软件推送数据结构

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2",
+        "lucide-react": "^0.577.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -2318,6 +2319,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.577.0",
+      "resolved": "https://registry.npmmirror.com/lucide-react/-/lucide-react-0.577.0.tgz",
+      "integrity": "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-opener": "^2",
+    "lucide-react": "^0.577.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9,6 +9,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1357,6 +1369,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1977,6 +2001,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1989,6 +2022,15 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -2709,6 +2751,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "libwayshot"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3006,6 +3059,15 @@ name = "noop_proc_macro"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "num-bigint"
@@ -4323,6 +4385,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+dependencies = [
+ "bitflags 2.11.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4489,9 +4565,11 @@ dependencies = [
  "image 0.25.9",
  "log",
  "reqwest 0.12.28",
+ "rusqlite",
  "screenshots",
  "serde",
  "serde_json",
+ "sysinfo",
  "tauri",
  "tauri-build",
  "tauri-plugin-autostart",
@@ -4502,6 +4580,7 @@ dependencies = [
  "tauri-plugin-single-instance",
  "tokio",
  "uuid",
+ "windows 0.52.0",
 ]
 
 [[package]]
@@ -4962,6 +5041,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.30.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "windows 0.52.0",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = ["tray-icon"] }
+tauri = { version = "2", features = ["tray-icon", "devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-http = "2"
@@ -34,4 +34,15 @@ uuid = { version = "1", features = ["v4"] }
 tauri-plugin-autostart = "2"
 tauri-plugin-global-shortcut = "2"
 tauri-plugin-single-instance = "2"
+sysinfo = "0.30"
+rusqlite = { version = "0.31", features = ["bundled"] }
+
+[target.'cfg(windows)'.dependencies]
+windows = { version = "0.52", features = [
+    "Win32_System_Threading",
+    "Win32_UI_WindowsAndMessaging",
+    "Win32_Foundation",
+    "Win32_System_ProcessStatus",
+    "Win32_Storage_FileSystem",
+] }
 

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -1,0 +1,296 @@
+use rusqlite::{Connection, Result as SqlResult, params};
+use std::path::PathBuf;
+use serde::{Deserialize, Serialize};
+use chrono::Local;
+
+/// 软件使用会话记录
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SoftwareSession {
+    pub id: String,
+    pub process_name: String,
+    pub window_title: String,
+    pub exe_path: String,
+    pub start_time: i64,
+    pub end_time: Option<i64>,
+    pub duration_secs: i64,
+    pub device_id: i64,
+    pub synced: bool,
+}
+
+impl SoftwareSession {
+    pub fn new(
+        process_name: String,
+        window_title: String,
+        exe_path: String,
+        device_id: i64,
+    ) -> Self {
+        Self {
+            id: uuid::Uuid::new_v4().to_string(),
+            process_name,
+            window_title,
+            exe_path,
+            start_time: Local::now().timestamp_millis(),
+            end_time: None,
+            duration_secs: 0,
+            device_id,
+            synced: false,
+        }
+    }
+}
+
+/// 同步队列记录
+#[derive(Debug)]
+pub struct SyncQueueItem {
+    pub id: i64,
+    pub session_id: String,
+    pub retry_count: i32,
+    pub next_retry_at: i64,
+}
+
+pub struct Database {
+    conn: Connection,
+}
+
+impl Database {
+    /// 初始化数据库连接
+    pub fn new() -> Result<Self, String> {
+        let db_path = Self::get_db_path()?;
+        let conn = Connection::open(db_path).map_err(|e| format!("打开数据库失败: {}", e))?;
+
+        let db = Self { conn };
+        db.init_tables()?;
+
+        Ok(db)
+    }
+
+    /// 获取数据库文件路径
+    fn get_db_path() -> Result<PathBuf, String> {
+        let data_dir = dirs::data_dir()
+            .ok_or("无法获取数据目录")?
+            .join("ScreenshotClient");
+
+        if !data_dir.exists() {
+            std::fs::create_dir_all(&data_dir).map_err(|e| format!("创建数据目录失败: {}", e))?;
+        }
+
+        Ok(data_dir.join("software_monitor.db"))
+    }
+
+    /// 初始化数据表
+    fn init_tables(&self) -> Result<(), String> {
+        // 软件使用会话表
+        self.conn.execute(
+            "CREATE TABLE IF NOT EXISTS software_sessions (
+                id TEXT PRIMARY KEY,
+                process_name TEXT NOT NULL,
+                window_title TEXT,
+                exe_path TEXT,
+                start_time INTEGER NOT NULL,
+                end_time INTEGER,
+                duration_secs INTEGER DEFAULT 0,
+                device_id INTEGER NOT NULL,
+                synced INTEGER DEFAULT 0,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )",
+            [],
+        ).map_err(|e| format!("创建software_sessions表失败: {}", e))?;
+
+        // 同步队列表
+        self.conn.execute(
+            "CREATE TABLE IF NOT EXISTS sync_queue (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL UNIQUE,
+                retry_count INTEGER DEFAULT 0,
+                next_retry_at INTEGER,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (session_id) REFERENCES software_sessions(id)
+            )",
+            [],
+        ).map_err(|e| format!("创建sync_queue表失败: {}", e))?;
+
+        // 创建索引
+        self.conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_sessions_device_time ON software_sessions(device_id, start_time)",
+            [],
+        ).map_err(|e| format!("创建索引失败: {}", e))?;
+
+        self.conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_sessions_synced ON software_sessions(synced)",
+            [],
+        ).map_err(|e| format!("创建索引失败: {}", e))?;
+
+        Ok(())
+    }
+
+    /// 插入新的会话记录
+    pub fn insert_session(&mut self, session: &SoftwareSession) -> Result<(), String> {
+        self.conn.execute(
+            "INSERT INTO software_sessions (id, process_name, window_title, exe_path, start_time, end_time, duration_secs, device_id, synced)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            params![
+                session.id,
+                session.process_name,
+                session.window_title,
+                session.exe_path,
+                session.start_time,
+                session.end_time,
+                session.duration_secs,
+                session.device_id,
+                if session.synced { 1 } else { 0 }
+            ],
+        ).map_err(|e| format!("插入会话记录失败: {}", e))?;
+
+        // 同时加入同步队列
+        self.add_to_sync_queue(&session.id)?;
+
+        Ok(())
+    }
+
+    /// 更新会话记录（结束时间和时长）
+    pub fn update_session_end(&mut self, session_id: &str, end_time: i64, duration_secs: i64) -> Result<(), String> {
+        self.conn.execute(
+            "UPDATE software_sessions SET end_time = ?1, duration_secs = ?2 WHERE id = ?3",
+            params![end_time, duration_secs, session_id],
+        ).map_err(|e| format!("更新会话记录失败: {}", e))?;
+
+        Ok(())
+    }
+
+    /// 更新会话窗口标题
+    pub fn update_session_title(&mut self, session_id: &str, window_title: &str) -> Result<(), String> {
+        self.conn.execute(
+            "UPDATE software_sessions SET window_title = ?1 WHERE id = ?2",
+            params![window_title, session_id],
+        ).map_err(|e| format!("更新窗口标题失败: {}", e))?;
+
+        Ok(())
+    }
+
+    /// 添加到同步队列
+    fn add_to_sync_queue(&mut self, session_id: &str) -> Result<(), String> {
+        let next_retry = Local::now().timestamp_millis();
+
+        self.conn.execute(
+            "INSERT OR IGNORE INTO sync_queue (session_id, next_retry_at) VALUES (?1, ?2)",
+            params![session_id, next_retry],
+        ).map_err(|e| format!("添加到同步队列失败: {}", e))?;
+
+        Ok(())
+    }
+
+    /// 获取待同步的记录
+    pub fn get_pending_sync(&self, limit: usize) -> Result<Vec<SoftwareSession>, String> {
+        let mut stmt = self.conn.prepare(
+            "SELECT s.id, s.process_name, s.window_title, s.exe_path, s.start_time, s.end_time, s.duration_secs, s.device_id, s.synced
+             FROM software_sessions s
+             INNER JOIN sync_queue q ON s.id = q.session_id
+             WHERE q.next_retry_at <= ?1
+             ORDER BY q.retry_count ASC, s.start_time ASC
+             LIMIT ?2"
+        ).map_err(|e| format!("准备查询失败: {}", e))?;
+
+        let current_time = Local::now().timestamp_millis();
+
+        let sessions = stmt.query_map(
+            params![current_time, limit as i64],
+            |row| {
+                Ok(SoftwareSession {
+                    id: row.get(0)?,
+                    process_name: row.get(1)?,
+                    window_title: row.get(2)?,
+                    exe_path: row.get(3)?,
+                    start_time: row.get(4)?,
+                    end_time: row.get(5)?,
+                    duration_secs: row.get(6)?,
+                    device_id: row.get(7)?,
+                    synced: row.get::<_, i32>(8)? != 0,
+                })
+            }
+        ).map_err(|e| format!("查询失败: {}", e))?;
+
+        let mut result = Vec::new();
+        for session in sessions {
+            result.push(session.map_err(|e| format!("解析会话失败: {}", e))?);
+        }
+
+        Ok(result)
+    }
+
+    /// 标记记录已同步
+    pub fn mark_synced(&mut self, session_ids: &[String]) -> Result<(), String> {
+        let tx = self.conn.transaction().map_err(|e| format!("开始事务失败: {}", e))?;
+
+        for id in session_ids {
+            tx.execute(
+                "UPDATE software_sessions SET synced = 1 WHERE id = ?1",
+                params![id],
+            ).map_err(|e| format!("标记同步状态失败: {}", e))?;
+
+            tx.execute(
+                "DELETE FROM sync_queue WHERE session_id = ?1",
+                params![id],
+            ).map_err(|e| format!("从同步队列删除失败: {}", e))?;
+        }
+
+        tx.commit().map_err(|e| format!("提交事务失败: {}", e))?;
+
+        Ok(())
+    }
+
+    /// 更新重试信息
+    pub fn update_retry(&mut self, session_id: &str, retry_count: i32, next_retry_at: i64) -> Result<(), String> {
+        self.conn.execute(
+            "UPDATE sync_queue SET retry_count = ?1, next_retry_at = ?2 WHERE session_id = ?3",
+            params![retry_count, next_retry_at, session_id],
+        ).map_err(|e| format!("更新重试信息失败: {}", e))?;
+
+        Ok(())
+    }
+
+    /// 删除超过30天的已同步记录（清理旧数据）
+    pub fn cleanup_old_records(&mut self, days: i32) -> Result<u32, String> {
+        let cutoff = Local::now().timestamp_millis() - (days as i64 * 24 * 60 * 60 * 1000);
+
+        let count = self.conn.execute(
+            "DELETE FROM software_sessions WHERE synced = 1 AND start_time < ?1",
+            params![cutoff],
+        ).map_err(|e| format!("清理旧记录失败: {}", e))?;
+
+        Ok(count as u32)
+    }
+
+    /// 获取统计数据
+    pub fn get_stats(&self) -> Result<(u32, u32), String> {
+        let total: i64 = self.conn.query_row(
+            "SELECT COUNT(*) FROM software_sessions",
+            [],
+            |row| row.get(0),
+        ).map_err(|e| format!("查询总数失败: {}", e))?;
+
+        let pending: i64 = self.conn.query_row(
+            "SELECT COUNT(*) FROM sync_queue",
+            [],
+            |row| row.get(0),
+        ).map_err(|e| format!("查询待同步数失败: {}", e))?;
+
+        Ok((total as u32, pending as u32))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_session_creation() {
+        let session = SoftwareSession::new(
+            "notepad.exe".to_string(),
+            "无标题 - 记事本".to_string(),
+            "C:\\Windows\\notepad.exe".to_string(),
+            123,
+        );
+
+        assert_eq!(session.process_name, "notepad.exe");
+        assert!(session.id.len() > 0);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1528,28 +1528,29 @@ async fn push_all_running_software(state: State<'_, AppState>) -> Result<(), Str
     println!("[push_all_running_software] 开始全量推送...");
 
     // 获取配置
-    let (api_url, device_code, token, device_name, class_name, school_class_id, device_type, dept_id) = {
+    let (api_url, device_code, token, school_class_id, dept_id) = {
         let config = state.config.lock().map_err(|e| e.to_string())?;
-        // 如果设备名称为空，使用设备类型作为默认名称
-        let final_device_name = if config.device_name.is_empty() {
-            "智能黑板".to_string() // 默认设备类型名称
-        } else {
-            config.device_name.clone()
-        };
+
+        // 验证关键字段
+        let dept_id = config.dept_id.ok_or("部门ID未配置，请先完成设备注册")?;
+        let school_class_id = config.school_class_id.ok_or("班级ID未配置，请先完成设备注册")?;
+
         (
             config.api_url.clone(),
             config.device_code.clone(),
             config.access_token.clone().unwrap_or_default(),
-            final_device_name,
-            config.class_name.clone(),
-            config.school_class_id.unwrap_or(0),
-            "智能黑板".to_string(), // 设备类型
-            config.dept_id.unwrap_or(0), // 部门ID
+            school_class_id,
+            dept_id,
         )
     };
 
     if token.is_empty() {
         return Err("未登录，无法推送软件信息".to_string());
+    }
+
+    // 验证 ID 有效性（避免使用 0 值）
+    if dept_id == 0 || school_class_id == 0 {
+        return Err(format!("部门ID({})或班级ID({})无效，请重新登录并完成设备注册", dept_id, school_class_id));
     }
 
     // 在独立线程执行进程枚举
@@ -1588,16 +1589,11 @@ async fn push_all_running_software(state: State<'_, AppState>) -> Result<(), Str
         return Ok(());
     }
 
-    // 构建请求体 - 按照API文档格式，添加设备信息和班级信息
+    // 构建请求体 - 严格按照API文档格式
     #[derive(Debug, serde::Serialize)]
     #[serde(rename_all = "camelCase")]
     struct BatchSoftwareRequest {
         device_code: String,
-        device_name: String,
-        device_type: String,
-        dept_id: i64,
-        class_id: i64,
-        class_name: String,
         sessions: Vec<SoftwareSessionPayload>,
     }
 
@@ -1612,15 +1608,12 @@ async fn push_all_running_software(state: State<'_, AppState>) -> Result<(), Str
         end_time: Option<i64>,
         duration_secs: i64,
         device_id: i64,
+        dept_id: i64,
+        class_id: i64,
     }
 
     let request = BatchSoftwareRequest {
         device_code: device_code.clone(),
-        device_name: device_name.clone(),
-        device_type: device_type.clone(),
-        dept_id,
-        class_id: school_class_id,
-        class_name: class_name.clone(),
         sessions: usages
             .into_iter()
             .map(|u| SoftwareSessionPayload {
@@ -1632,6 +1625,8 @@ async fn push_all_running_software(state: State<'_, AppState>) -> Result<(), Str
                 end_time: None,
                 duration_secs: 0,
                 device_id: 0,
+                dept_id,
+                class_id: school_class_id,
             })
             .collect(),
     };
@@ -1676,28 +1671,29 @@ async fn push_software_realtime(
     event_type: &str, // "started" 或 "stopped"
     session: &crate::database::SoftwareSession,
 ) -> Result<(), String> {
-    let (api_url, device_code, token, device_name, _class_name, school_class_id, device_type, dept_id) = {
+    let (api_url, device_code, token, school_class_id, dept_id) = {
         let config = state.config.lock().map_err(|e| e.to_string())?;
-        // 如果设备名称为空，使用设备类型作为默认名称
-        let final_device_name = if config.device_name.is_empty() {
-            "智能黑板".to_string()
-        } else {
-            config.device_name.clone()
-        };
+
+        // 验证关键字段
+        let dept_id = config.dept_id.ok_or("部门ID未配置，请先完成设备注册")?;
+        let school_class_id = config.school_class_id.ok_or("班级ID未配置，请先完成设备注册")?;
+
         (
             config.api_url.clone(),
             config.device_code.clone(),
             config.access_token.clone().unwrap_or_default(),
-            final_device_name,
-            config.class_name.clone(),
-            config.school_class_id.unwrap_or(0),
-            "智能黑板".to_string(),
-            config.dept_id.unwrap_or(0), // 部门ID
+            school_class_id,
+            dept_id,
         )
     };
 
     if token.is_empty() {
         return Err("未登录".to_string());
+    }
+
+    // 验证 ID 有效性（避免使用 0 值）
+    if dept_id == 0 || school_class_id == 0 {
+        return Err(format!("部门ID({})或班级ID({})无效，请重新登录并完成设备注册", dept_id, school_class_id));
     }
 
     // 严格按照API文档构建请求体
@@ -1706,11 +1702,6 @@ async fn push_software_realtime(
     #[serde(rename_all = "camelCase")]
     struct RealtimeRequest {
         device_code: String,
-        device_name: String,
-        device_type: String,
-        dept_id: i64,
-        class_id: i64,
-        class_name: String,
         event: String,
         session: SessionPayload,
     }
@@ -1729,6 +1720,8 @@ async fn push_software_realtime(
         duration_secs: Option<i64>,
         #[serde(skip_serializing_if = "Option::is_none")]
         device_id: Option<i64>,
+        dept_id: i64,
+        class_id: i64,
     }
 
     let session_payload = SessionPayload {
@@ -1740,15 +1733,12 @@ async fn push_software_realtime(
         end_time: session.end_time,
         duration_secs: if event_type == "stopped" { Some(session.duration_secs) } else { None },
         device_id: Some(session.device_id),
+        dept_id,
+        class_id: school_class_id,
     };
 
     let request = RealtimeRequest {
         device_code,
-        device_name,
-        device_type,
-        dept_id,
-        class_id: school_class_id,
-        class_name: _class_name,
         event: event_type.to_string(),
         session: session_payload,
     };

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,10 +4,15 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::io::Cursor;
 use std::path::PathBuf;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
 use tauri::State;
 use tauri::Manager;
 use tauri::tray::{TrayIconBuilder, TrayIconEvent};
+use tokio::sync::watch;
+
+mod database;
+mod monitor;
 
 // 配置结构
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -29,6 +34,7 @@ pub struct AppConfig {
     pub device_code: String,       // 设备编码（MAC地址）
     pub device_name: String,       // 设备名称
     pub school_class_id: Option<i64>,  // 班级ID
+    pub class_name: String,          // 班级名称
     pub device_id: Option<i64>,     // 注册后返回的设备ID
     pub is_registered: bool,       // 是否已注册
     pub dept_id: Option<i64>,      // 学校/部门ID
@@ -38,6 +44,10 @@ pub struct AppConfig {
     // 后台运行配置
     pub autostart_enabled: bool,    // 开机自启开关
     pub show_window_on_start: bool, // 启动时是否显示窗口
+    // 软件监控配置
+    pub software_monitor_enabled: bool,      // 是否启用软件监控
+    pub software_monitor_interval_secs: u32, // 轮询间隔（秒）
+    pub software_monitor_batch_secs: u32,    // 批量上报间隔（秒）
 }
 
 impl Default for AppConfig {
@@ -66,6 +76,7 @@ impl Default for AppConfig {
             device_code: String::new(),
             device_name: String::new(),
             school_class_id: None,
+            class_name: String::new(),
             device_id: None,
             is_registered: false,
             dept_id: None,
@@ -74,7 +85,11 @@ impl Default for AppConfig {
             refresh_token: None,
             // 后台运行默认值
             autostart_enabled: true,
-            show_window_on_start: false,
+            show_window_on_start: true,
+            // 软件监控默认值
+            software_monitor_enabled: true,
+            software_monitor_interval_secs: 5,
+            software_monitor_batch_secs: 300,
         }
     }
 }
@@ -82,6 +97,7 @@ impl Default for AppConfig {
 pub struct AppState {
     pub config: Mutex<AppConfig>,
     pub is_running: Mutex<bool>,
+    pub monitor_shutdown: Mutex<Option<watch::Sender<bool>>>,
 }
 
 fn get_config_path() -> PathBuf {
@@ -98,13 +114,28 @@ fn get_config_path() -> PathBuf {
 
 fn load_config() -> AppConfig {
     let path = get_config_path();
+    println!("[load_config] 配置文件路径: {:?}", path);
+    println!("[load_config] 文件是否存在: {}", path.exists());
     if path.exists() {
-        if let Ok(content) = fs::read_to_string(&path) {
-            if let Ok(config) = serde_json::from_str(&content) {
-                return config;
+        match fs::read_to_string(&path) {
+            Ok(content) => {
+                println!("[load_config] 文件读取成功, 长度: {}", content.len());
+                match serde_json::from_str::<AppConfig>(&content) {
+                    Ok(config) => {
+                        println!("[load_config] JSON解析成功");
+                        return config;
+                    }
+                    Err(e) => {
+                        println!("[load_config] JSON解析失败: {}", e);
+                    }
+                }
+            }
+            Err(e) => {
+                println!("[load_config] 文件读取失败: {}", e);
             }
         }
     }
+    println!("[load_config] 使用默认配置");
     AppConfig::default()
 }
 
@@ -117,29 +148,34 @@ fn save_config(config: &AppConfig) -> Result<(), String> {
 }
 
 #[tauri::command]
-fn capture_screen() -> Result<String, String> {
+async fn capture_screen() -> Result<String, String> {
     use screenshots::image::ImageOutputFormat;
 
-    let screens = screenshots::Screen::all().map_err(|e| e.to_string())?;
+    // 在独立线程中执行截图，避免阻塞主线程
+    let result = tokio::task::spawn_blocking(move || {
+        let screens = screenshots::Screen::all().map_err(|e| e.to_string())?;
 
-    if screens.is_empty() {
-        return Err("没有找到显示器".to_string());
-    }
+        if screens.is_empty() {
+            return Err("没有找到显示器".to_string());
+        }
 
-    let screen = &screens[0];
-    let capture = screen.capture().map_err(|e| e.to_string())?;
+        let screen = &screens[0];
+        let capture = screen.capture().map_err(|e| e.to_string())?;
 
-    let mut buffer = Cursor::new(Vec::new());
-    capture
-        .write_to(&mut buffer, ImageOutputFormat::Png)
-        .map_err(|e| e.to_string())?;
+        let mut buffer = Cursor::new(Vec::new());
+        capture
+            .write_to(&mut buffer, ImageOutputFormat::Png)
+            .map_err(|e| e.to_string())?;
 
-    let base64_data = base64::Engine::encode(
-        &base64::engine::general_purpose::STANDARD,
-        buffer.into_inner(),
-    );
+        let base64_data = base64::Engine::encode(
+            &base64::engine::general_purpose::STANDARD,
+            buffer.into_inner(),
+        );
 
-    Ok(format!("data:image/png;base64,{}", base64_data))
+        Ok(format!("data:image/png;base64,{}", base64_data))
+    }).await;
+
+    result.map_err(|e| format!("截图任务执行失败: {}", e))?
 }
 
 #[tauri::command]
@@ -630,10 +666,11 @@ async fn register_device(
     device_name: String,
     school_class_id: i64,
     device_type: Option<i32>,
+    class_name: String,  // 新增：班级名称
     state: State<'_, AppState>,
 ) -> Result<RegisterData, String> {
     println!("[register_device] 开始设备注册...");
-    println!("[register_device] 设备名称: {}, 班级ID: {}", device_name, school_class_id);
+    println!("[register_device] 设备名称: {}, 班级ID: {}, 班级名称: {}", device_name, school_class_id, class_name);
 
     // 使用作用域限制锁的生命周期，避免死锁
     let (token, device_code, dept_id, api_url) = {
@@ -730,10 +767,12 @@ async fn register_device(
                 let mut config = state.config.lock().map_err(|e| e.to_string())?;
                 config.device_name = data.device_name.clone();
                 config.school_class_id = Some(school_class_id);
+                // 使用传入的班级名称，如果后端返回了班级名称则优先使用
+                config.class_name = data.classroom_name.clone().unwrap_or_else(|| class_name.clone());
                 config.device_id = Some(data.id);
                 config.is_registered = true;
                 save_config(&config)?;
-                println!("[register_device] 注册信息保存成功");
+                println!("[register_device] 注册信息保存成功, 班级: {}", config.class_name);
 
                 Ok(data)
             } else {
@@ -742,6 +781,7 @@ async fn register_device(
                 let mut config = state.config.lock().map_err(|e| e.to_string())?;
                 config.device_name = device_name.clone();
                 config.school_class_id = Some(school_class_id);
+                config.class_name = class_name.clone();  // 保存班级名称
                 config.is_registered = true;
                 save_config(&config)?;
 
@@ -881,19 +921,22 @@ async fn upload_screenshot_v2(
         return Err("设备未注册".to_string());
     }
 
-    // 解析 Base64 图片数据
+    // 解析 Base64 图片数据（支持 PNG 和 JPEG 格式）
     let base64_data = image_data
         .strip_prefix("data:image/png;base64,")
+        .or_else(|| image_data.strip_prefix("data:image/jpeg;base64,"))
         .unwrap_or(&image_data);
 
     let image_bytes = base64::Engine::decode(
         &base64::engine::general_purpose::STANDARD,
         base64_data,
-    ).map_err(|e| e.to_string())?;
+    ).map_err(|e| format!("Base64解码失败: {}", e))?;
 
     // 加载图片
     let img = image::load_from_memory(&image_bytes)
         .map_err(|e| format!("加载图片失败: {}", e))?;
+
+    println!("[VideoPush] 原始图片: {}x{} bytes, 设备: {}", img.width(), img.height(), device_code);
 
     // 调整分辨率（最大1280x720）
     let resized_img = resize_image_for_stream(&img);
@@ -926,16 +969,24 @@ async fn upload_screenshot_v2(
         .await
         .map_err(|e| e.to_string())?;
 
-    if response.status().is_success() {
-        let result: serde_json::Value = response.json().await.map_err(|e| e.to_string())?;
+    let status = response.status();
+    let body = response.text().await.map_err(|e| e.to_string())?;
+    println!("[VideoPush] API响应: status={}, body={}", status, body);
+
+    if status.is_success() {
+        let result: serde_json::Value = serde_json::from_str(&body).map_err(|e| e.to_string())?;
         let code = result.get("code").and_then(|c| c.as_i64()).unwrap_or(-1);
         if code == 0 || code == 200 {
+            println!("[VideoPush] 推流成功");
             Ok(true)
         } else {
-            Err(result.get("msg").and_then(|m| m.as_str()).unwrap_or("上传失败").to_string())
+            let msg = result.get("msg").and_then(|m| m.as_str()).unwrap_or("上传失败").to_string();
+            println!("[VideoPush] 推流失败: {}", msg);
+            Err(msg)
         }
     } else {
-        Err(format!("上传失败: {}", response.status()))
+        println!("[VideoPush] HTTP错误: {}", status);
+        Err(format!("上传失败: {}", status))
     }
 }
 
@@ -1072,6 +1123,7 @@ pub fn run() {
         .manage(AppState {
             config: Mutex::new(config),
             is_running: Mutex::new(false),
+            monitor_shutdown: Mutex::new(None),
         })
         .invoke_handler(tauri::generate_handler![
             capture_screen,
@@ -1095,24 +1147,41 @@ pub fn run() {
             upload_screenshot_file,
             toggle_window,
             exit_app,
+            start_software_monitor,
+            stop_software_monitor,
+            get_software_monitor_stats,
+            get_software_usages,
+            push_all_running_software,
         ])
         .setup(move |app| {
+            println!("[setup] ========== setup 钩子开始执行 ==========");
+
             // 获取命令行参数
             let args: Vec<String> = std::env::args().collect();
             let from_autostart = is_autostart(&args);
+            println!("[setup] 启动参数: {:?}, 是否自启: {}", args, from_autostart);
 
             // 创建系统托盘
-            let tray = TrayIconBuilder::new()
-                .icon(app.default_window_icon().unwrap().clone())
-                .tooltip("截图客户端")
-                .show_menu_on_left_click(false)
-                .on_tray_icon_event(|tray, event| {
-                    if let TrayIconEvent::Click { .. } = event {
-                        let app = tray.app_handle();
-                        toggle_window_visibility(app);
-                    }
-                })
-                .build(app)?;
+            println!("[setup] 创建系统托盘...");
+            if let Some(icon) = app.default_window_icon() {
+                match TrayIconBuilder::new()
+                    .icon(icon.clone())
+                    .tooltip("截图客户端")
+                    .show_menu_on_left_click(false)
+                    .on_tray_icon_event(|tray, event| {
+                        if let TrayIconEvent::Click { .. } = event {
+                            let app = tray.app_handle();
+                            toggle_window_visibility(app);
+                        }
+                    })
+                    .build(app)
+                {
+                    Ok(_) => println!("[setup] 托盘创建成功"),
+                    Err(e) => println!("[setup] 托盘创建失败（非致命）: {}", e),
+                }
+            } else {
+                println!("[setup] 警告: 无法获取默认窗口图标，跳过托盘创建");
+            }
 
             // 设置全局快捷键 Ctrl+Shift+S（暂时禁用，避免热键冲突）
             // #[cfg(desktop)]
@@ -1143,6 +1212,17 @@ pub fn run() {
             println!("setup: 开始设置窗口");
             if let Some(window) = app.get_webview_window("main") {
                 println!("setup: 获取到主窗口");
+
+                // 启用开发者工具快捷键 (F12)
+                #[cfg(debug_assertions)]
+                {
+                    window.open_devtools();
+                }
+
+                // 确保窗口可以调整大小
+                let _ = window.set_resizable(true);
+                let _ = window.set_min_size(Some(tauri::LogicalSize::new(600.0, 400.0)));
+
                 let window_clone = window.clone();
                 window.on_window_event(move |event| {
                     if let tauri::WindowEvent::CloseRequested { api, .. } = event {
@@ -1162,11 +1242,24 @@ pub fn run() {
                     let focus_result = window.set_focus();
                     println!("setup: show_result = {:?}, focus_result = {:?}", show_result, focus_result);
                 } else {
-                    println!("已登录且已注册，最小化到托盘");
-                    let _ = window.hide();
+                    println!("已登录且已注册，显示窗口");
+                    // 临时显示窗口用于预览
+                    let _ = window.show();
+                    let _ = window.set_focus();
                 }
             } else {
                 println!("setup: 未能获取主窗口");
+            }
+
+            // 启动软件监控服务（如果已登录且已注册且配置启用）
+            if !need_show_window {
+                println!("启动软件监控服务...");
+                let app_handle = app.app_handle().clone();
+                tauri::async_runtime::spawn(async move {
+                    if let Err(e) = init_software_monitor(app_handle).await {
+                        log::error!("启动软件监控失败: {}", e);
+                    }
+                });
             }
 
             Ok(())
@@ -1195,6 +1288,502 @@ fn toggle_window(app: tauri::AppHandle) {
 
 // 命令：完全退出应用
 #[tauri::command]
-fn exit_app(app: tauri::AppHandle) {
+async fn exit_app(app: tauri::AppHandle, state: State<'_, AppState>) -> Result<(), String> {
+    // 停止软件监控服务
+    stop_software_monitor_internal(&state).await;
     app.exit(0);
+    Ok(())
+}
+
+// ========== 软件监控相关命令 ==========
+
+use crate::monitor::{
+    run_background_sync, MonitorConfig, MonitorEvent, ProcessMonitor, SessionManager,
+    SyncConfig, SyncScheduler,
+};
+
+/// 初始化软件监控服务
+async fn init_software_monitor(app: tauri::AppHandle) -> Result<(), String> {
+    let state = app.state::<AppState>();
+
+    // 获取配置
+    let (enabled, device_id, api_url, device_code, token, interval_secs, batch_secs) = {
+        let config = state.config.lock().map_err(|e| e.to_string())?;
+        (
+            config.software_monitor_enabled,
+            config.device_id.unwrap_or(0),
+            config.api_url.clone(),
+            config.device_code.clone(),
+            config.access_token.clone().unwrap_or_default(),
+            config.software_monitor_interval_secs,
+            config.software_monitor_batch_secs,
+        )
+    };
+
+    if !enabled {
+        log::info!("软件监控已禁用");
+        return Ok(());
+    }
+
+    if device_id == 0 {
+        log::warn!("设备ID未设置，无法启动软件监控");
+        return Ok(());
+    }
+
+    // 创建会话管理器
+    let mut session_manager = SessionManager::new(device_id)?;
+    let db = session_manager.get_db();
+
+    // 创建同步调度器
+    let sync_config = SyncConfig {
+        api_url,
+        device_code,
+        token,
+        batch_interval: Duration::from_secs(batch_secs as u64),
+        ..Default::default()
+    };
+    let sync_scheduler = SyncScheduler::new(sync_config, db.clone())?;
+
+    // 创建关闭信号
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    {
+        let mut shutdown_guard = state.monitor_shutdown.lock().map_err(|e| e.to_string())?;
+        *shutdown_guard = Some(shutdown_tx);
+    }
+
+    // 启动后台同步任务
+    tokio::spawn(run_background_sync(sync_scheduler, shutdown_rx));
+
+    // 启动监控循环
+    let monitor_config = MonitorConfig {
+        check_interval: Duration::from_secs(interval_secs as u64),
+        device_id,
+        ..Default::default()
+    };
+    let mut monitor = ProcessMonitor::new(monitor_config);
+
+    log::info!("软件监控服务已启动");
+
+    // 启动时立即推送一次全量软件列表
+    println!("[init_software_monitor] 启动时推送全量软件列表...");
+    if let Err(e) = push_all_running_software(state.clone().into()).await {
+        log::error!("启动时全量推送失败: {}", e);
+    }
+
+    // 监控循环
+    loop {
+        // 检查关闭信号
+        {
+            let shutdown_guard = state.monitor_shutdown.lock().map_err(|e| e.to_string())?;
+            if shutdown_guard.is_none() {
+                log::info!("收到关闭信号，停止软件监控");
+                break;
+            }
+        }
+
+        // 执行一次轮询
+        let events = monitor.tick();
+
+        for event in events {
+            match &event {
+                MonitorEvent::SessionStarted(session) => {
+                    log::debug!("软件启动: {} - {}", session.process_name, session.window_title);
+                    // 新软件打开时，实时推送 started 事件
+                    println!("[monitor] 新软件启动，实时推送: {}", session.process_name);
+                    if let Err(e) = push_software_realtime(&state, "started", session).await {
+                        log::error!("实时推送软件启动失败: {}", e);
+                    }
+                }
+                MonitorEvent::SessionEnded(session) => {
+                    log::debug!("软件关闭: {}，使用时长: {}秒", session.process_name, session.duration_secs);
+                    // 软件关闭时，实时推送 stopped 事件
+                    println!("[monitor] 软件关闭，实时推送: {}", session.process_name);
+                    if let Err(e) = push_software_realtime(&state, "stopped", session).await {
+                        log::error!("实时推送软件关闭失败: {}", e);
+                    }
+                }
+                _ => {}
+            }
+
+            // 处理事件
+            if let Err(e) = session_manager.handle_event(&event) {
+                log::error!("处理监控事件失败: {}", e);
+            }
+        }
+
+        // 等待下一次轮询
+        tokio::time::sleep(Duration::from_secs(interval_secs as u64)).await;
+    }
+
+    // 关闭当前活跃会话
+    if let Some(session) = session_manager.close_active_session()? {
+        log::info!("关闭活跃会话: {}", session.process_name);
+    }
+
+    Ok(())
+}
+
+/// 停止软件监控服务
+async fn stop_software_monitor_internal(state: &AppState) {
+    let mut shutdown_guard = state.monitor_shutdown.lock().unwrap();
+    if let Some(tx) = shutdown_guard.take() {
+        let _ = tx.send(true);
+        log::info!("已发送软件监控关闭信号");
+    }
+}
+
+/// 命令：启动软件监控
+#[tauri::command]
+async fn start_software_monitor(app: tauri::AppHandle) -> Result<(), String> {
+    init_software_monitor(app).await
+}
+
+/// 命令：停止软件监控
+#[tauri::command]
+async fn stop_software_monitor(state: State<'_, AppState>) -> Result<(), String> {
+    stop_software_monitor_internal(&state).await;
+    Ok(())
+}
+
+/// 命令：获取软件监控统计信息
+#[tauri::command]
+fn get_software_monitor_stats(state: State<AppState>) -> Result<serde_json::Value, String> {
+    use crate::database::Database;
+
+    let device_id = {
+        let config = state.config.lock().map_err(|e| e.to_string())?;
+        config.device_id.unwrap_or(0)
+    };
+
+    let db = Database::new()?;
+    let (total, pending) = db.get_stats()?;
+
+    Ok(serde_json::json!({
+        "total_sessions": total,
+        "pending_sync": pending,
+        "device_id": device_id,
+    }))
+}
+
+/// 软件使用信息结构体
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SoftwareUsage {
+    id: String,
+    process_name: String,
+    window_title: String,
+    is_active: bool,
+    duration_secs: u32,
+    last_active_time: String,
+}
+
+/// 命令：获取当前运行的软件列表（在独立线程执行避免阻塞UI）
+#[tauri::command]
+async fn get_software_usages() -> Result<Vec<SoftwareUsage>, String> {
+    use crate::monitor::windows_api::{enumerate_user_processes, get_foreground_process};
+    use std::sync::mpsc;
+
+    println!("[get_software_usages] 开始执行...");
+
+    // 在独立线程执行进程枚举
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let processes = enumerate_user_processes();
+
+        let foreground = get_foreground_process();
+        let foreground_pid = foreground.as_ref().map(|p| p.pid);
+
+        // 限制返回数量，优先保留前台进程和常用软件
+        let max_count = 30;
+        let usages: Vec<SoftwareUsage> = processes
+            .into_iter()
+            .take(max_count)
+            .map(|p| {
+                let is_active = Some(p.pid) == foreground_pid;
+                SoftwareUsage {
+                    id: p.pid.to_string(),
+                    process_name: p.name.clone(),
+                    window_title: p.window_title.clone(),
+                    is_active,
+                    duration_secs: 0,
+                    last_active_time: chrono::Local::now().to_rfc3339(),
+                }
+            })
+            .collect();
+
+        println!("[get_software_usages] 返回 {} 个软件", usages.len());
+        let _ = tx.send(usages);
+    });
+
+    let usages = rx.recv().map_err(|e| e.to_string())?;
+    Ok(usages)
+}
+
+/// 全量推送当前运行软件列表到服务器
+#[tauri::command]
+async fn push_all_running_software(state: State<'_, AppState>) -> Result<(), String> {
+    use crate::monitor::windows_api::{enumerate_user_processes, get_foreground_process};
+    use std::sync::mpsc;
+
+    println!("[push_all_running_software] 开始全量推送...");
+
+    // 获取配置
+    let (api_url, device_code, token, device_name, class_name, school_class_id, device_type, dept_id) = {
+        let config = state.config.lock().map_err(|e| e.to_string())?;
+        // 如果设备名称为空，使用设备类型作为默认名称
+        let final_device_name = if config.device_name.is_empty() {
+            "智能黑板".to_string() // 默认设备类型名称
+        } else {
+            config.device_name.clone()
+        };
+        (
+            config.api_url.clone(),
+            config.device_code.clone(),
+            config.access_token.clone().unwrap_or_default(),
+            final_device_name,
+            config.class_name.clone(),
+            config.school_class_id.unwrap_or(0),
+            "智能黑板".to_string(), // 设备类型
+            config.dept_id.unwrap_or(0), // 部门ID
+        )
+    };
+
+    if token.is_empty() {
+        return Err("未登录，无法推送软件信息".to_string());
+    }
+
+    // 在独立线程执行进程枚举
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let processes = enumerate_user_processes();
+        let foreground = get_foreground_process();
+        let foreground_pid = foreground.as_ref().map(|p| p.pid);
+
+        // 限制返回数量
+        let max_count = 50;
+        let usages: Vec<SoftwareUsage> = processes
+            .into_iter()
+            .take(max_count)
+            .map(|p| {
+                let is_active = Some(p.pid) == foreground_pid;
+                SoftwareUsage {
+                    id: p.pid.to_string(),
+                    process_name: p.name.clone(),
+                    window_title: p.window_title.clone(),
+                    is_active,
+                    duration_secs: 0,
+                    last_active_time: chrono::Local::now().to_rfc3339(),
+                }
+            })
+            .collect();
+
+        let _ = tx.send(usages);
+    });
+
+    let usages = rx.recv().map_err(|e| e.to_string())?;
+    println!("[push_all_running_software] 获取到 {} 个软件", usages.len());
+
+    if usages.is_empty() {
+        println!("[push_all_running_software] 没有运行中的软件，跳过推送");
+        return Ok(());
+    }
+
+    // 构建请求体 - 按照API文档格式，添加设备信息和班级信息
+    #[derive(Debug, serde::Serialize)]
+    #[serde(rename_all = "camelCase")]
+    struct BatchSoftwareRequest {
+        device_code: String,
+        device_name: String,
+        device_type: String,
+        dept_id: i64,
+        class_id: i64,
+        class_name: String,
+        sessions: Vec<SoftwareSessionPayload>,
+    }
+
+    #[derive(Debug, serde::Serialize)]
+    #[serde(rename_all = "camelCase")]
+    struct SoftwareSessionPayload {
+        id: String,
+        process_name: String,
+        window_title: String,
+        exe_path: String,
+        start_time: i64,
+        end_time: Option<i64>,
+        duration_secs: i64,
+        device_id: i64,
+    }
+
+    let request = BatchSoftwareRequest {
+        device_code: device_code.clone(),
+        device_name: device_name.clone(),
+        device_type: device_type.clone(),
+        dept_id,
+        class_id: school_class_id,
+        class_name: class_name.clone(),
+        sessions: usages
+            .into_iter()
+            .map(|u| SoftwareSessionPayload {
+                id: u.id.clone(),
+                process_name: u.process_name,
+                window_title: u.window_title,
+                exe_path: String::new(), // 全量推送时可能没有exe_path
+                start_time: chrono::Local::now().timestamp_millis(),
+                end_time: None,
+                duration_secs: 0,
+                device_id: 0,
+            })
+            .collect(),
+    };
+
+    // 打印调试信息
+    let request_json = serde_json::to_string_pretty(&request).unwrap_or_default();
+    println!("[push_all_running_software] 批量推送请求体:\n{}", request_json);
+
+    // 发送全量推送请求
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .no_proxy()
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    let response = client
+        .post(&format!("{}/client/software/usage/batch", api_url))
+        .header("Authorization", format!("Bearer {}", token))
+        .json(&request)
+        .send()
+        .await
+        .map_err(|e| format!("网络请求失败: {}", e))?;
+
+    if response.status().is_success() {
+        let result: serde_json::Value = response.json().await.map_err(|e| e.to_string())?;
+        let code = result.get("code").and_then(|c| c.as_i64()).unwrap_or(-1);
+        if code == 0 || code == 200 {
+            println!("[push_all_running_software] 全量推送成功");
+            Ok(())
+        } else {
+            let msg = result.get("msg").and_then(|m| m.as_str()).unwrap_or("推送失败");
+            Err(format!("服务器返回错误: {}", msg))
+        }
+    } else {
+        Err(format!("HTTP错误: {}", response.status()))
+    }
+}
+
+/// 推送单个软件使用信息到服务器 - 严格按照API文档格式
+async fn push_software_realtime(
+    state: &AppState,
+    event_type: &str, // "started" 或 "stopped"
+    session: &crate::database::SoftwareSession,
+) -> Result<(), String> {
+    let (api_url, device_code, token, device_name, _class_name, school_class_id, device_type, dept_id) = {
+        let config = state.config.lock().map_err(|e| e.to_string())?;
+        // 如果设备名称为空，使用设备类型作为默认名称
+        let final_device_name = if config.device_name.is_empty() {
+            "智能黑板".to_string()
+        } else {
+            config.device_name.clone()
+        };
+        (
+            config.api_url.clone(),
+            config.device_code.clone(),
+            config.access_token.clone().unwrap_or_default(),
+            final_device_name,
+            config.class_name.clone(),
+            config.school_class_id.unwrap_or(0),
+            "智能黑板".to_string(),
+            config.dept_id.unwrap_or(0), // 部门ID
+        )
+    };
+
+    if token.is_empty() {
+        return Err("未登录".to_string());
+    }
+
+    // 严格按照API文档构建请求体
+    // API文档要求: deviceCode, event, session
+    #[derive(Debug, serde::Serialize)]
+    #[serde(rename_all = "camelCase")]
+    struct RealtimeRequest {
+        device_code: String,
+        device_name: String,
+        device_type: String,
+        dept_id: i64,
+        class_id: i64,
+        class_name: String,
+        event: String,
+        session: SessionPayload,
+    }
+
+    #[derive(Debug, serde::Serialize)]
+    #[serde(rename_all = "camelCase")]
+    struct SessionPayload {
+        id: String,
+        process_name: String,
+        window_title: String,
+        exe_path: String,
+        start_time: i64,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        end_time: Option<i64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        duration_secs: Option<i64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        device_id: Option<i64>,
+    }
+
+    let session_payload = SessionPayload {
+        id: session.id.clone(),
+        process_name: session.process_name.clone(),
+        window_title: session.window_title.clone(),
+        exe_path: session.exe_path.clone(),
+        start_time: session.start_time,
+        end_time: session.end_time,
+        duration_secs: if event_type == "stopped" { Some(session.duration_secs) } else { None },
+        device_id: Some(session.device_id),
+    };
+
+    let request = RealtimeRequest {
+        device_code,
+        device_name,
+        device_type,
+        dept_id,
+        class_id: school_class_id,
+        class_name: _class_name,
+        event: event_type.to_string(),
+        session: session_payload,
+    };
+
+    // 打印调试信息
+    let request_json = serde_json::to_string_pretty(&request).unwrap_or_default();
+    println!("[push_software_realtime] 实时推送请求体:\n{}", request_json);
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .no_proxy()
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    println!("[push_software_realtime] 推送 {} 事件: {}", event_type, session.process_name);
+
+    let response = client
+        .post(&format!("{}/client/software/usage/realtime", api_url))
+        .header("Authorization", format!("Bearer {}", token))
+        .json(&request)
+        .send()
+        .await
+        .map_err(|e| format!("网络请求失败: {}", e))?;
+
+    if response.status().is_success() {
+        let result: serde_json::Value = response.json().await.map_err(|e| e.to_string())?;
+        let code = result.get("code").and_then(|c| c.as_i64()).unwrap_or(-1);
+        if code == 0 || code == 200 {
+            println!("[push_software_realtime] 推送成功: {}", session.process_name);
+            Ok(())
+        } else {
+            let msg = result.get("msg").and_then(|m| m.as_str()).unwrap_or("推送失败");
+            Err(format!("服务器返回错误: {}", msg))
+        }
+    } else {
+        Err(format!("HTTP错误: {}", response.status()))
+    }
 }

--- a/src-tauri/src/monitor/mod.rs
+++ b/src-tauri/src/monitor/mod.rs
@@ -1,0 +1,8 @@
+pub mod windows_api;
+pub mod process_monitor;
+pub mod session_manager;
+pub mod sync_scheduler;
+
+pub use process_monitor::{ProcessMonitor, MonitorEvent, MonitorConfig, ActiveSession};
+pub use session_manager::SessionManager;
+pub use sync_scheduler::{SyncScheduler, SyncConfig, run_background_sync};

--- a/src-tauri/src/monitor/process_monitor.rs
+++ b/src-tauri/src/monitor/process_monitor.rs
@@ -1,0 +1,227 @@
+use crate::database::SoftwareSession;
+use crate::monitor::windows_api::{get_foreground_process, ProcessInfo, should_monitor};
+use std::time::{Duration, Instant};
+
+/// 监控事件类型
+#[derive(Debug, Clone)]
+pub enum MonitorEvent {
+    /// 新会话开始
+    SessionStarted(SoftwareSession),
+    /// 会话切换（旧会话结束，新会话开始）
+    SessionSwitched {
+        ended_session: SoftwareSession,
+        new_session: SoftwareSession,
+    },
+    /// 当前会话结束
+    SessionEnded(SoftwareSession),
+    /// 使用时长更新
+    UsageUpdated {
+        session_id: String,
+        duration_secs: i64,
+        window_title: Option<String>,
+    },
+}
+
+/// 活跃会话信息
+#[derive(Debug, Clone)]
+pub struct ActiveSession {
+    pub session: SoftwareSession,
+    pub last_active_time: Instant,
+    pub last_window_title: String,
+    pub total_active_secs: i64,
+}
+
+/// 进程监控配置
+#[derive(Debug, Clone)]
+pub struct MonitorConfig {
+    /// 轮询间隔
+    pub check_interval: Duration,
+    /// 闲置阈值（超过此时间未活动则认为闲置）
+    pub idle_threshold: Duration,
+    /// 设备ID
+    pub device_id: i64,
+}
+
+impl Default for MonitorConfig {
+    fn default() -> Self {
+        Self {
+            check_interval: Duration::from_secs(5),
+            idle_threshold: Duration::from_secs(300), // 5分钟
+            device_id: 0,
+        }
+    }
+}
+
+/// 进程监控器
+pub struct ProcessMonitor {
+    config: MonitorConfig,
+    active_session: Option<ActiveSession>,
+    last_check_time: Instant,
+}
+
+impl ProcessMonitor {
+    /// 创建新的监控器
+    pub fn new(config: MonitorConfig) -> Self {
+        Self {
+            config,
+            active_session: None,
+            last_check_time: Instant::now(),
+        }
+    }
+
+    /// 执行一次轮询检查
+    /// 返回产生的事件列表
+    pub fn tick(&mut self) -> Vec<MonitorEvent> {
+        let now = Instant::now();
+        let elapsed = now.duration_since(self.last_check_time);
+        self.last_check_time = now;
+
+        let mut events = Vec::new();
+
+        // 获取当前前台进程
+        let current_process = match get_foreground_process() {
+            Some(p) => p,
+            None => {
+                // 没有前台进程，结束当前会话
+                if let Some(active) = self.active_session.take() {
+                    events.push(self.end_session(active));
+                }
+                return events;
+            }
+        };
+
+        // 判断是否应该监控此进程
+        if !should_monitor(&current_process) {
+            // 不应该监控，结束当前会话（如果有）
+            if let Some(active) = self.active_session.take() {
+                events.push(self.end_session(active));
+            }
+            return events;
+        }
+
+        // 检查是否是当前活跃会话
+        let idle_threshold = self.config.idle_threshold;
+        match &mut self.active_session {
+            Some(active) => {
+                if active.session.process_name == current_process.name {
+                    // 同一会话，更新信息
+                    let event = Self::update_active_session(active, &current_process, elapsed, idle_threshold);
+                    if let Some(e) = event {
+                        events.push(e);
+                    }
+                } else {
+                    // 会话切换
+                    let old_session = self.active_session.take().unwrap();
+                    events.push(self.end_session(old_session));
+
+                    let new_session = self.start_session(&current_process);
+                    events.push(MonitorEvent::SessionStarted(new_session.session.clone()));
+                    self.active_session = Some(new_session);
+                }
+            }
+            None => {
+                // 新会话
+                let new_session = self.start_session(&current_process);
+                events.push(MonitorEvent::SessionStarted(new_session.session.clone()));
+                self.active_session = Some(new_session);
+            }
+        }
+
+        events
+    }
+
+    /// 开始新会话
+    fn start_session(&self, process: &ProcessInfo) -> ActiveSession {
+        let session = SoftwareSession::new(
+            process.name.clone(),
+            process.window_title.clone(),
+            process.exe_path.clone(),
+            self.config.device_id,
+        );
+
+        ActiveSession {
+            last_active_time: Instant::now(),
+            last_window_title: process.window_title.clone(),
+            total_active_secs: 0,
+            session,
+        }
+    }
+
+    /// 结束会话
+    fn end_session(&self, mut active: ActiveSession) -> MonitorEvent {
+        let end_time = chrono::Local::now().timestamp_millis();
+        active.session.end_time = Some(end_time);
+        active.session.duration_secs = active.total_active_secs;
+
+        MonitorEvent::SessionEnded(active.session)
+    }
+
+    /// 更新活跃会话
+    fn update_active_session(
+        active: &mut ActiveSession,
+        process: &ProcessInfo,
+        elapsed: Duration,
+        idle_threshold: Duration,
+    ) -> Option<MonitorEvent> {
+        let elapsed_secs = elapsed.as_secs() as i64;
+
+        // 检测闲置状态
+        if process.window_title != active.last_window_title {
+            // 窗口标题变化，重置活跃时间
+            active.last_active_time = Instant::now();
+            active.last_window_title = process.window_title.clone();
+
+            // 窗口标题变化，通知更新
+            return Some(MonitorEvent::UsageUpdated {
+                session_id: active.session.id.clone(),
+                duration_secs: active.total_active_secs,
+                window_title: Some(process.window_title.clone()),
+            });
+        }
+
+        // 检查是否闲置
+        let idle_time = Instant::now().duration_since(active.last_active_time);
+        if idle_time < idle_threshold {
+            // 未闲置，累加使用时长
+            active.total_active_secs += elapsed_secs;
+
+            // 每30秒上报一次使用时长
+            if active.total_active_secs % 30 < elapsed_secs {
+                return Some(MonitorEvent::UsageUpdated {
+                    session_id: active.session.id.clone(),
+                    duration_secs: active.total_active_secs,
+                    window_title: None,
+                });
+            }
+        }
+
+        None
+    }
+
+    /// 强制结束当前会话（用于应用退出时）
+    pub fn force_end_session(&mut self) -> Option<MonitorEvent> {
+        self.active_session.take().map(|active| self.end_session(active))
+    }
+
+    /// 获取当前活跃会话信息
+    pub fn get_active_session(&self) -> Option<&ActiveSession> {
+        self.active_session.as_ref()
+    }
+
+    /// 更新配置
+    pub fn update_config(&mut self, config: MonitorConfig) {
+        self.config = config;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_monitor_config_default() {
+        let config = MonitorConfig::default();
+        assert_eq!(config.check_interval, Duration::from_secs(5));
+        assert_eq!(config.idle_threshold, Duration::from_secs(300));
+    }
+}

--- a/src-tauri/src/monitor/session_manager.rs
+++ b/src-tauri/src/monitor/session_manager.rs
@@ -1,0 +1,162 @@
+use crate::database::{Database, SoftwareSession};
+use crate::monitor::process_monitor::{ActiveSession, MonitorEvent};
+use chrono::Local;
+use std::sync::{Arc, Mutex};
+
+/// 会话管理器
+/// 负责处理监控事件，管理会话生命周期，持久化到数据库
+pub struct SessionManager {
+    db: Arc<Mutex<Database>>,
+    active_session: Option<ActiveSession>,
+    device_id: i64,
+}
+
+impl SessionManager {
+    /// 创建新的会话管理器
+    pub fn new(device_id: i64) -> Result<Self, String> {
+        let db = Database::new()?;
+
+        Ok(Self {
+            db: Arc::new(Mutex::new(db)),
+            active_session: None,
+            device_id,
+        })
+    }
+
+    /// 处理监控事件
+    pub fn handle_event(&mut self,
+        event: &MonitorEvent,
+    ) -> Result<Option<SoftwareSession>, String> {
+        match event {
+            MonitorEvent::SessionStarted(session) => {
+                // 插入新会话到数据库
+                let mut db = self.db.lock().map_err(|e| format!("获取数据库锁失败: {}", e))?;
+                db.insert_session(session)?;
+
+                // 创建活跃会话
+                let active = ActiveSession {
+                    session: session.clone(),
+                    last_active_time: std::time::Instant::now(),
+                    last_window_title: session.window_title.clone(),
+                    total_active_secs: 0,
+                };
+                self.active_session = Some(active);
+
+                Ok(Some(session.clone()))
+            }
+
+            MonitorEvent::SessionSwitched { ended_session, new_session } => {
+                // 更新结束的会话
+                let end_time = Local::now().timestamp_millis();
+                let duration = (end_time - ended_session.start_time) / 1000;
+
+                {
+                    let mut db = self.db.lock().map_err(|e| format!("获取数据库锁失败: {}", e))?;
+                    db.update_session_end(&ended_session.id, end_time, duration)?;
+                }
+
+                // 插入新会话
+                {
+                    let mut db = self.db.lock().map_err(|e| format!("获取数据库锁失败: {}", e))?;
+                    db.insert_session(new_session)?;
+                }
+
+                // 更新活跃会话
+                let active = ActiveSession {
+                    session: new_session.clone(),
+                    last_active_time: std::time::Instant::now(),
+                    last_window_title: new_session.window_title.clone(),
+                    total_active_secs: 0,
+                };
+                self.active_session = Some(active);
+
+                Ok(Some(new_session.clone()))
+            }
+
+            MonitorEvent::SessionEnded(session) => {
+                let end_time = Local::now().timestamp_millis();
+                let duration = session.duration_secs;
+
+                {
+                    let mut db = self.db.lock().map_err(|e| format!("获取数据库锁失败: {}", e))?;
+                    db.update_session_end(&session.id, end_time, duration)?;
+                }
+
+                self.active_session = None;
+
+                Ok(Some(session.clone()))
+            }
+
+            MonitorEvent::UsageUpdated { session_id, duration_secs, window_title } => {
+                // 更新会话时长和窗口标题
+                if let Some(active) = &mut self.active_session {
+                    if active.session.id == *session_id {
+                        active.total_active_secs = *duration_secs;
+
+                        if let Some(title) = window_title {
+                            active.last_window_title = title.clone();
+                            active.session.window_title = title.clone();
+
+                            let mut db = self.db.lock().map_err(|e| format!("获取数据库锁失败: {}", e))?;
+                            db.update_session_title(session_id, title)?;
+                        }
+                    }
+                }
+
+                Ok(None)
+            }
+        }
+    }
+
+    /// 关闭当前活跃会话（应用退出时调用）
+    pub fn close_active_session(&mut self,
+    ) -> Result<Option<SoftwareSession>, String> {
+        if let Some(active) = self.active_session.take() {
+            let end_time = Local::now().timestamp_millis();
+            let duration = active.total_active_secs;
+
+            {
+                let mut db = self.db.lock().map_err(|e| format!("获取数据库锁失败: {}", e))?;
+                db.update_session_end(&active.session.id, end_time, duration)?;
+            }
+
+            let mut session = active.session.clone();
+            session.end_time = Some(end_time);
+            session.duration_secs = duration;
+
+            Ok(Some(session))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// 获取当前活跃会话
+    pub fn get_active_session(&self,
+    ) -> Option<&ActiveSession> {
+        self.active_session.as_ref()
+    }
+
+    /// 获取数据库实例（用于同步调度器）
+    pub fn get_db(&self,
+    ) -> Arc<Mutex<Database>> {
+        self.db.clone()
+    }
+
+    /// 获取统计数据
+    pub fn get_stats(&self,
+    ) -> Result<(u32, u32), String> {
+        let db = self.db.lock().map_err(|e| format!("获取数据库锁失败: {}", e))?;
+        db.get_stats()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_session_manager() {
+        // 需要实际数据库环境
+        // 在生产环境测试
+    }
+}

--- a/src-tauri/src/monitor/sync_scheduler.rs
+++ b/src-tauri/src/monitor/sync_scheduler.rs
@@ -1,0 +1,307 @@
+use crate::database::{Database, SoftwareSession};
+use crate::monitor::process_monitor::MonitorEvent;
+use reqwest::Client;
+use serde::Serialize;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+use tokio::time::sleep;
+
+/// 同步错误类型
+#[derive(Debug)]
+pub enum SyncError {
+    Network(String),
+    Server(u16, String),
+    Database(String),
+    MaxRetriesReached,
+}
+
+impl std::fmt::Display for SyncError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SyncError::Network(msg) => write!(f, "网络错误: {}", msg),
+            SyncError::Server(status, msg) => write!(f, "服务器错误 {}: {}", status, msg),
+            SyncError::Database(msg) => write!(f, "数据库错误: {}", msg),
+            SyncError::MaxRetriesReached => write!(f, "达到最大重试次数"),
+        }
+    }
+}
+
+impl std::error::Error for SyncError {}
+
+/// 实时上报请求体
+#[derive(Debug, Serialize)]
+struct RealtimeRequest {
+    device_code: String,
+    event: String,
+    session: SessionPayload,
+}
+
+/// 会话数据
+#[derive(Debug, Serialize)]
+struct SessionPayload {
+    id: String,
+    process_name: String,
+    window_title: String,
+    exe_path: String,
+    start_time: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    end_time: Option<i64>,
+    duration_secs: i64,
+    device_id: i64,
+}
+
+impl From<&SoftwareSession> for SessionPayload {
+    fn from(s: &SoftwareSession) -> Self {
+        Self {
+            id: s.id.clone(),
+            process_name: s.process_name.clone(),
+            window_title: s.window_title.clone(),
+            exe_path: s.exe_path.clone(),
+            start_time: s.start_time,
+            end_time: s.end_time,
+            duration_secs: s.duration_secs,
+            device_id: s.device_id,
+        }
+    }
+}
+
+/// 批量上报请求体
+#[derive(Debug, Serialize)]
+struct BatchRequest {
+    device_code: String,
+    sessions: Vec<SessionPayload>,
+}
+
+/// 同步调度器配置
+#[derive(Debug, Clone)]
+pub struct SyncConfig {
+    pub api_url: String,
+    pub device_code: String,
+    pub token: String,
+    pub batch_interval: Duration,
+    pub max_retries: u32,
+    pub batch_size: usize,
+}
+
+impl Default for SyncConfig {
+    fn default() -> Self {
+        Self {
+            api_url: String::new(),
+            device_code: String::new(),
+            token: String::new(),
+            batch_interval: Duration::from_secs(300), // 5分钟
+            max_retries: 5,
+            batch_size: 50,
+        }
+    }
+}
+
+/// 同步调度器
+pub struct SyncScheduler {
+    config: SyncConfig,
+    db: Arc<Mutex<Database>>,
+    client: Client,
+    last_batch_time: Instant,
+}
+
+impl SyncScheduler {
+    /// 创建新的同步调度器
+    pub fn new(config: SyncConfig, db: Arc<Mutex<Database>>) -> Result<Self, String> {
+        let client = Client::builder()
+            .timeout(Duration::from_secs(30))
+            .no_proxy()
+            .build()
+            .map_err(|e| format!("创建HTTP客户端失败: {}", e))?;
+
+        Ok(Self {
+            config,
+            db,
+            client,
+            last_batch_time: Instant::now(),
+        })
+    }
+
+    /// 发送实时事件
+    pub async fn send_realtime(&self, event: &MonitorEvent) -> Result<(), SyncError> {
+        let request = match event {
+            MonitorEvent::SessionStarted(session) => {
+                Some(("started", session))
+            }
+            MonitorEvent::SessionEnded(session) => {
+                Some(("ended", session))
+            }
+            MonitorEvent::SessionSwitched { new_session, .. } => {
+                Some(("switched", new_session))
+            }
+            _ => None,
+        };
+
+        if let Some((event_type, session)) = request {
+            let payload = RealtimeRequest {
+                device_code: self.config.device_code.clone(),
+                event: event_type.to_string(),
+                session: session.into(),
+            };
+
+            let response = self
+                .client
+                .post(format!("{}/client/software/usage/realtime", self.config.api_url))
+                .header("Authorization", format!("Bearer {}", self.config.token))
+                .json(&payload)
+                .send()
+                .await
+                .map_err(|e| SyncError::Network(e.to_string()))?;
+
+            if !response.status().is_success() {
+                let status = response.status().as_u16();
+                let text = response.text().await.unwrap_or_default();
+                return Err(SyncError::Server(status, text));
+            }
+
+            // 实时上报成功，标记为已同步
+            self.mark_synced(&[session.id.clone()]).await?;
+        }
+
+        Ok(())
+    }
+
+    /// 执行批量同步
+    pub async fn sync_batch(&mut self) -> Result<u32, SyncError> {
+        let sessions = {
+            let db = self.db.lock().map_err(|e| SyncError::Database(e.to_string()))?;
+            db.get_pending_sync(self.config.batch_size)
+                .map_err(|e| SyncError::Database(e))?
+        };
+
+        if sessions.is_empty() {
+            return Ok(0);
+        }
+
+        let payload = BatchRequest {
+            device_code: self.config.device_code.clone(),
+            sessions: sessions.iter().map(|s| s.into()).collect(),
+        };
+
+        let response = self
+            .client
+            .post(format!("{}/client/software/usage/batch", self.config.api_url))
+            .header("Authorization", format!("Bearer {}", self.config.token))
+            .json(&payload)
+            .send()
+            .await
+            .map_err(|e| SyncError::Network(e.to_string()))?;
+
+        if response.status().is_success() {
+            // 批量上报成功
+            let ids: Vec<String> = sessions.iter().map(|s| s.id.clone()).collect();
+            self.mark_synced(&ids).await?;
+
+            self.last_batch_time = Instant::now();
+            Ok(sessions.len() as u32)
+        } else {
+            // 上报失败，更新重试信息
+            let status = response.status().as_u16();
+            let text = response.text().await.unwrap_or_default();
+
+            // 4xx错误不重试
+            if (400..500).contains(&status) {
+                let ids: Vec<String> = sessions.iter().map(|s| s.id.clone()).collect();
+                self.mark_synced(&ids).await?; // 标记为已处理，不再重试
+                return Err(SyncError::Server(status, text));
+            }
+
+            // 5xx错误更新重试计数
+            self.update_retry_info(&sessions).await?;
+            Err(SyncError::Server(status, text))
+        }
+    }
+
+    /// 标记记录已同步
+    async fn mark_synced(&self, ids: &[String]) -> Result<(), SyncError> {
+        let mut db = self.db.lock().map_err(|e| SyncError::Database(e.to_string()))?;
+        db.mark_synced(&ids.to_vec())
+            .map_err(|e| SyncError::Database(e))?;
+        Ok(())
+    }
+
+    /// 更新重试信息
+    async fn update_retry_info(&self, sessions: &[SoftwareSession]) -> Result<(), SyncError> {
+        use chrono::Local;
+
+        let mut db = self.db.lock().map_err(|e| SyncError::Database(e.to_string()))?;
+
+        for session in sessions {
+            // 从数据库查询当前重试次数
+            let next_retry = Local::now().timestamp_millis() + 60000; // 1分钟后重试
+            db.update_retry(&session.id, 1, next_retry)
+                .map_err(|e| SyncError::Database(e))?;
+        }
+
+        Ok(())
+    }
+
+    /// 检查是否应该执行批量同步
+    pub fn should_sync_batch(&self) -> bool {
+        Instant::now().duration_since(self.last_batch_time) >= self.config.batch_interval
+    }
+
+    /// 更新配置
+    pub fn update_config(&mut self, config: SyncConfig) {
+        self.config = config;
+    }
+
+    /// 带退避重试的批量同步
+    pub async fn sync_batch_with_retry(&mut self) -> Result<u32, SyncError> {
+        let mut retries = 0;
+
+        loop {
+            match self.sync_batch().await {
+                Ok(count) => return Ok(count),
+                Err(e) => {
+                    retries += 1;
+
+                    if retries >= self.config.max_retries {
+                        return Err(SyncError::MaxRetriesReached);
+                    }
+
+                    // 指数退避等待
+                    let wait_secs = 2_u64.pow(retries);
+                    sleep(Duration::from_secs(wait_secs)).await;
+                }
+            }
+        }
+    }
+}
+
+/// 运行后台同步任务
+pub async fn run_background_sync(
+    mut scheduler: SyncScheduler,
+    mut shutdown: tokio::sync::watch::Receiver<bool>,
+) {
+    let mut interval = tokio::time::interval(Duration::from_secs(60)); // 每分钟检查一次
+
+    loop {
+        tokio::select! {
+            _ = interval.tick() => {
+                if scheduler.should_sync_batch() {
+                    if let Err(e) = scheduler.sync_batch_with_retry().await {
+                        log::error!("批量同步失败: {}", e);
+                    }
+                }
+            }
+            _ = shutdown.changed() => {
+                if *shutdown.borrow() {
+                    log::info!("收到关闭信号，停止后台同步任务");
+                    break;
+                }
+            }
+        }
+    }
+
+    // 退出前尝试最后一次同步
+    log::info!("应用退出前执行最后一次同步...");
+    match scheduler.sync_batch_with_retry().await {
+        Ok(count) => log::info!("最后同步完成: {} 条记录", count),
+        Err(e) => log::error!("最后同步失败: {}", e),
+    }
+}

--- a/src-tauri/src/monitor/windows_api.rs
+++ b/src-tauri/src/monitor/windows_api.rs
@@ -1,0 +1,272 @@
+use std::ffi::OsString;
+use std::os::windows::ffi::OsStringExt;
+use std::path::Path;
+use windows::Win32::Foundation::{CloseHandle, HWND, MAX_PATH};
+use windows::Win32::System::ProcessStatus::{
+    GetModuleBaseNameW, GetModuleFileNameExW,
+};
+use windows::Win32::System::Threading::{GetCurrentProcessId, OpenProcess, PROCESS_QUERY_INFORMATION, PROCESS_VM_READ};
+use windows::Win32::UI::WindowsAndMessaging::{
+    GetForegroundWindow, GetWindowTextW, GetWindowThreadProcessId,
+};
+
+/// 进程信息结构
+#[derive(Debug, Clone)]
+pub struct ProcessInfo {
+    pub pid: u32,
+    pub name: String,
+    pub exe_path: String,
+    pub window_title: String,
+}
+
+impl ProcessInfo {
+    /// 获取进程可执行文件名（不含路径）
+    pub fn exe_name(&self) -> String {
+        Path::new(&self.exe_path)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or(&self.name)
+            .to_string()
+    }
+}
+
+/// 获取当前前台窗口的进程信息
+pub fn get_foreground_process() -> Option<ProcessInfo> {
+    unsafe {
+        // 获取前台窗口句柄
+        let hwnd = GetForegroundWindow();
+        if hwnd.0 == 0 {
+            return None;
+        }
+
+        // 获取窗口标题
+        let mut title_buffer = [0u16; 512];
+        let title_len = GetWindowTextW(hwnd, &mut title_buffer);
+        let window_title = if title_len > 0 {
+            OsString::from_wide(&title_buffer[..title_len as usize])
+                .to_string_lossy()
+                .to_string()
+        } else {
+            String::new()
+        };
+
+        // 获取窗口所属的进程ID
+        let mut pid: u32 = 0;
+        GetWindowThreadProcessId(hwnd, Some(&mut pid));
+
+        if pid == 0 {
+            return None;
+        }
+
+        // 排除自身进程
+        if pid == GetCurrentProcessId() {
+            return None;
+        }
+
+        // 打开进程获取详细信息
+        let process_handle = OpenProcess(
+            PROCESS_QUERY_INFORMATION | PROCESS_VM_READ,
+            false,
+            pid,
+        );
+
+        if process_handle.is_err() {
+            // 无法打开进程（可能是系统进程或权限不足）
+            return Some(ProcessInfo {
+                pid,
+                name: format!("PID_{}", pid),
+                exe_path: String::new(),
+                window_title,
+            });
+        }
+
+        let handle = process_handle.unwrap();
+
+        // 获取进程模块路径
+        let mut path_buffer = [0u16; MAX_PATH as usize];
+        let path_len = GetModuleFileNameExW(handle, None, &mut path_buffer);
+
+        let exe_path = if path_len > 0 {
+            OsString::from_wide(&path_buffer[..path_len as usize])
+                .to_string_lossy()
+                .to_string()
+        } else {
+            String::new()
+        };
+
+        // 获取进程名
+        let mut name_buffer = [0u16; 512];
+        let name_len = GetModuleBaseNameW(handle, None, &mut name_buffer);
+
+        let name = if name_len > 0 {
+            OsString::from_wide(&name_buffer[..name_len as usize])
+                .to_string_lossy()
+                .to_string()
+        } else {
+            exe_path
+                .split('\\')
+                .last()
+                .unwrap_or("unknown")
+                .to_string()
+        };
+
+        let _ = CloseHandle(handle);
+
+        Some(ProcessInfo {
+            pid,
+            name,
+            exe_path,
+            window_title,
+        })
+    }
+}
+
+/// 判断是否为系统进程（需要排除）
+pub fn is_system_process(exe_path: &str) -> bool {
+    if exe_path.is_empty() {
+        return false;
+    }
+
+    let exe_lower = exe_path.to_lowercase();
+
+    // 首先检查是否是已知的系统可执行文件（无论路径）
+    if is_system_exe(&exe_lower) {
+        return true;
+    }
+
+    // 系统目录列表 - 这些目录下的非白名单程序也排除
+    let system_dirs = [
+        "c:\\windows\\system32",
+        "c:\\windows\\syswow64",
+    ];
+
+    // 检查是否在系统目录
+    for dir in &system_dirs {
+        if exe_lower.starts_with(dir) {
+            // 在系统目录下，检查是否是允许的白名单程序
+            return !is_whitelisted_system_exe(&exe_lower);
+        }
+    }
+
+    false
+}
+
+/// 系统白名单程序（允许显示）
+fn is_whitelisted_system_exe(exe_lower: &str) -> bool {
+    let whitelist = [
+        "notepad.exe",
+        "mspaint.exe",
+        "calc.exe",
+        "wordpad.exe",
+    ];
+    whitelist.iter().any(|exe| exe_lower.ends_with(exe))
+}
+
+/// 判断是否为特定的系统可执行文件
+fn is_system_exe(exe_lower: &str) -> bool {
+    let system_exes = [
+        "svchost.exe",
+        "services.exe",
+        "lsass.exe",
+        "csrss.exe",
+        "smss.exe",
+        "winlogon.exe",
+        "wininit.exe",
+        "dwm.exe",
+        "taskhostw.exe",
+        "sihost.exe",
+        "explorer.exe", // 资源管理器虽然常用，但作为系统进程排除
+        "searchindexer.exe",
+        "searchui.exe",
+        "runtimebroker.exe",
+        "dllhost.exe",
+        "backgroundtaskhost.exe",
+        "conhost.exe",
+        "cmd.exe", // 命令行工具排除
+        "powershell.exe",
+        "pwsh.exe",
+    ];
+
+    system_exes.iter().any(|exe| exe_lower.ends_with(exe))
+}
+
+/// 判断是否为应该被监控的用户应用程序
+pub fn should_monitor(info: &ProcessInfo) -> bool {
+    // 空路径不监控
+    if info.exe_path.is_empty() {
+        return false;
+    }
+
+    // 排除系统进程
+    if is_system_process(&info.exe_path) {
+        return false;
+    }
+
+    true
+}
+
+/// 获取所有用户进程的列表（用于初始化或统计）
+pub fn enumerate_user_processes() -> Vec<ProcessInfo> {
+    use sysinfo::{ProcessRefreshKind, RefreshKind, System};
+
+    println!("[enumerate_user_processes] 开始获取进程列表...");
+    let s = System::new_with_specifics(
+        RefreshKind::new().with_processes(ProcessRefreshKind::new()),
+    );
+
+    let all_count = s.processes().len();
+    println!("[enumerate_user_processes] 系统总进程数: {}", all_count);
+
+    let result: Vec<ProcessInfo> = s.processes()
+        .iter()
+        .filter_map(|(pid, process)| {
+            let exe_path = process.exe().map(|p| p.to_string_lossy().to_string()).unwrap_or_default();
+            let name = process.name().to_string();
+
+            // 排除空名称的进程
+            if name.is_empty() {
+                return None;
+            }
+
+            // 排除系统进程（检查路径和进程名）
+            let path_to_check = if exe_path.is_empty() { &name } else { &exe_path };
+            if is_system_process(path_to_check) {
+                return None;
+            }
+
+            Some(ProcessInfo {
+                pid: pid.as_u32(),
+                name: name.clone(),
+                exe_path: if exe_path.is_empty() { name.clone() } else { exe_path },
+                window_title: String::new(), // sysinfo 无法直接获取窗口标题
+            })
+        })
+        .collect();
+
+    println!("[enumerate_user_processes] 过滤后进程数: {}", result.len());
+    if !result.is_empty() {
+        println!("[enumerate_user_processes] 前3个进程: {:?}", &result[..3.min(result.len())]);
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_system_process() {
+        assert!(is_system_process("C:\\Windows\\System32\\svchost.exe"));
+        assert!(is_system_process("C:\\Windows\\explorer.exe"));
+        assert!(!is_system_process("C:\\Program Files\\Chrome\\chrome.exe"));
+        assert!(!is_system_process("C:\\Users\\Test\\AppData\\Local\\Discord\\app.exe"));
+    }
+
+    #[test]
+    fn test_get_foreground_process() {
+        // 运行时需要Windows环境
+        let result = get_foreground_process();
+        println!("Foreground process: {:?}", result);
+    }
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -13,12 +13,15 @@
     "windows": [
       {
         "title": "截图客户端",
-        "width": 400,
-        "height": 500,
+        "width": 1000,
+        "height": 700,
+        "minWidth": 800,
+        "minHeight": 600,
         "resizable": true,
         "center": true,
         "visible": true,
-        "skipTaskbar": false
+        "skipTaskbar": false,
+        "decorations": true
       }
     ],
     "trayIcon": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,8 @@
-import React, { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { DeviceSetupWrapper } from "./DeviceSetupWrapper";
-
-// 设备类型名称
-const deviceTypeMap: Record<number, string> = {
-  1: '智能黑板',
-  2: '智能多媒体设备',
-  3: '其他'
-};
+import { ThemeProvider } from "./contexts/ThemeContext";
+import { Dashboard } from "./components/Dashboard";
 
 
 
@@ -30,6 +25,7 @@ const MOCK_CONFIG = {
   device_code: "",
   device_name: "",
   school_class_id: null,
+  class_name: "",
   device_id: null,
   is_registered: false,
   dept_id: null,
@@ -59,6 +55,7 @@ interface AppConfig {
   device_code: string;
   device_name: string;
   school_class_id: number | null;
+  class_name: string;
   device_id: number | null;
   is_registered: boolean;
   dept_id: number | null;
@@ -88,7 +85,7 @@ function App() {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [loginError, setLoginError] = useState("");
-  const [isOnline, setIsOnline] = useState(true);
+  const [isOnline] = useState(true);
   const [statusMessage, setStatusMessage] = useState("");
   const [cameraError, setCameraError] = useState<string | null>(null);
   const [isInitialized, setIsInitialized] = useState(false);
@@ -100,20 +97,20 @@ function App() {
   const [showDeviceSetup, setShowDeviceSetup] = useState(false);
   const [classList, setClassList] = useState<Array<{ id: number; class_name: string }>>([]);
 
-  const videoRef = useRef<HTMLVideoElement>(null);
-  const canvasRef = useRef<HTMLCanvasElement>(null);
-  const timerRef = useRef<number | null>(null);
-  const heartbeatTimerRef = useRef<number | null>(null);
-  const screenshotTimerRef = useRef<number | null>(null);
-  const streamRef = useRef<MediaStream | null>(null);
-  const currentImageRef = useRef<string | null>(null);
-
   // 分辨率映射
   const resolutionMap: Record<string, { width: number; height: number }> = {
     "480p": { width: 640, height: 360 },
     "720p": { width: 1280, height: 720 },
     "1080p": { width: 1920, height: 1080 },
   };
+
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const timerRef = useRef<number | null>(null);
+  const screenshotTimerRef = useRef<number | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const currentImageRef = useRef<string | null>(null);
+  const isCapturingRef = useRef<boolean>(false); // 防止同时多次截图
 
   // 初始化：加载配置（只在组件挂载时执行一次）
   useEffect(() => {
@@ -146,7 +143,7 @@ function App() {
       try {
         setStatusMessage("正在自动登录...");
         
-        const loginResult = await invoke<{
+        await invoke<{
           user_id: number;
           username: string;
           dept_id: number;
@@ -158,6 +155,12 @@ function App() {
 
         console.log("自动登录成功");
         setIsLoggedIn(true);
+
+        // 登录成功后立即推送一次当前运行软件列表
+        console.log("[App] 登录成功，推送当前运行软件列表...");
+        invoke("push_all_running_software")
+          .then(() => console.log("[App] 软件列表推送成功"))
+          .catch((e) => console.error("[App] 软件列表推送失败:", e));
 
         // 检查是否已注册设备
         if (config.is_registered) {
@@ -195,15 +198,6 @@ function App() {
   //     }
   //   };
   // }, [isLoggedIn, config?.is_registered, showDeviceSetup]);
-
-  // 发送心跳
-  const sendHeartbeat = async () => {
-    try {
-      await invoke("send_heartbeat");
-    } catch (e) {
-      console.error("心跳失败:", e);
-    }
-  };
 
   // 检测摄像头
   // 检测摄像头是否可用（包括权限检查）
@@ -258,12 +252,14 @@ function App() {
   useEffect(() => {
     if (showDeviceSetup) return; // 设备设置页面不启动截图
     if (!config || isInitialized || !isLoggedIn) return;
-    
+
     // 延迟启动截图，给注册流程足够时间完成
     const timer = setTimeout(() => {
       setIsInitialized(true);
       selectCaptureMode().then((mode) => {
+        // 同步更新 state 和 ref
         setActualCaptureMode(mode);
+        captureModeRef.current = mode;
         setStatusMessage(`使用${mode === "camera" ? "摄像头" : "屏幕截图"}模式`);
         if (mode === "camera") {
           initCamera().then(() => {
@@ -271,6 +267,7 @@ function App() {
               startCaptureLoop();
             } else {
               setActualCaptureMode("screen");
+              captureModeRef.current = "screen";
               startCaptureLoop();
             }
           });
@@ -279,7 +276,7 @@ function App() {
         }
       });
     }, 500); // 500ms 延迟，确保注册流程完成
-    
+
     return () => clearTimeout(timer);
   }, [config, isLoggedIn, showDeviceSetup]);
 
@@ -298,11 +295,17 @@ function App() {
     console.log("[handleDeviceRegisterInternal] 开始注册:", { classId, deviceType, deviceName });
 
     try {
+      // 查找班级名称
+      const selectedClass = classList.find(c => c.id === classId);
+      const className = selectedClass?.class_name || "";
+      console.log("[handleDeviceRegisterInternal] 班级名称:", className);
+
       // 直接调用注册
       await invoke("register_device", {
         deviceName: deviceName,
         schoolClassId: classId,
-        deviceType: deviceType
+        deviceType: deviceType,
+        className: className
       });
 
       console.log("[handleDeviceRegisterInternal] 注册成功");
@@ -321,16 +324,6 @@ function App() {
     }
   };
 
-  const checkNetwork = async () => {
-    if (!config) return;
-    try {
-      const online = await invoke<boolean>("check_network", { apiUrl: config.api_url });
-      setIsOnline(online);
-    } catch {
-      setIsOnline(false);
-    }
-  };
-
   // 初始化摄像头
   const initCamera = async () => {
     try {
@@ -344,8 +337,10 @@ function App() {
       const stream = await navigator.mediaDevices.getUserMedia({
         video: {
           width: { ideal: width },
-          height: { ideal: height }
-        }
+          height: { ideal: height },
+          facingMode: 'user'
+        },
+        audio: false
       });
 
       // 停止之前的流
@@ -355,8 +350,17 @@ function App() {
 
       streamRef.current = stream;
 
+      // 设置 video 元素的 srcObject
       if (videoRef.current) {
         videoRef.current.srcObject = stream;
+        // 等待视频准备好
+        await new Promise<void>((resolve, reject) => {
+          if (!videoRef.current) return reject(new Error("Video element not found"));
+          videoRef.current.onloadedmetadata = () => resolve();
+          videoRef.current.onerror = () => reject(new Error("Video load error"));
+          // 5秒超时
+          setTimeout(() => reject(new Error("Video init timeout")), 5000);
+        });
         await videoRef.current.play();
       }
 
@@ -378,14 +382,40 @@ function App() {
   };
 
   // 启动采集循环
-  const startCaptureLoop = () => {
+  const startCaptureLoop = async () => {
+    // 如果是摄像头模式，先等待摄像头准备好
+    if (captureModeRef.current === "camera") {
+      // 最多等待5秒
+      let attempts = 0;
+      const maxAttempts = 50; // 5秒 (50 * 100ms)
+
+      while ((!videoRef.current || videoRef.current?.videoWidth === 0) && attempts < maxAttempts) {
+        await new Promise(resolve => setTimeout(resolve, 100));
+        attempts++;
+      }
+
+      if (attempts >= maxAttempts) {
+        console.warn("Camera initialization timeout, switching to screen mode");
+        setActualCaptureMode("screen");
+        captureModeRef.current = "screen";
+        setCameraError("摄像头初始化超时");
+      } else {
+        console.log("Camera ready after", attempts * 100, "ms");
+      }
+    }
+
+    // 根据模式设置不同的捕获间隔
+    // 摄像头模式：500ms (2fps)
+    // 截图模式：1000ms (1fps) - 降低频率避免卡顿
+    const captureInterval = captureModeRef.current === "camera" ? 500 : 1000;
+
     // 立即执行一次
     captureAndPushFrame();
 
-    // 视频推送：每500ms（2帧/秒）
+    // 视频推送定时器
     timerRef.current = window.setInterval(() => {
       captureAndPushFrame();
-    }, 500);
+    }, captureInterval);
 
     // 截图上传：每5分钟上传一次（用于后台查看静态画面）
     uploadScreenshotFile();
@@ -395,32 +425,54 @@ function App() {
   };
 
   // 捕获帧并推送到视频流（每500ms调用一次，2帧/秒）
+  const captureFrameCount = useRef(0);
+  const pushSuccessCount = useRef(0);
+  const pushFailCount = useRef(0);
+  const captureModeRef = useRef(actualCaptureMode);
+
+  // 同步 actualCaptureMode 到 ref
+  useEffect(() => {
+    captureModeRef.current = actualCaptureMode;
+    console.log('[App] Capture mode changed to:', actualCaptureMode);
+  }, [actualCaptureMode]);
+
   const captureAndPushFrame = async () => {
     if (!config) return;
 
-    // 使用实际选择的采集模式
-    const captureMode = actualCaptureMode;
+    captureFrameCount.current++;
+    const captureMode = captureModeRef.current;
 
-    // 摄像头模式
-    if (captureMode === "camera" && hasCamera && !cameraError && videoRef.current && canvasRef.current) {
+    // 每30秒输出一次调试信息
+    if (captureFrameCount.current % 60 === 0) {
+      console.log(`[VideoPush] mode=${captureModeRef.current}, frames=${captureFrameCount.current}, success=${pushSuccessCount.current}, fail=${pushFailCount.current}`);
+    }
+
+    // 摄像头模式 - 只有当明确是摄像头模式且 video 就绪时才使用摄像头
+    if (captureMode === "camera" && hasCamera && !cameraError) {
+      if (!videoRef.current || !canvasRef.current) {
+        return;
+      }
+
+      const video = videoRef.current;
+
+      if (video.videoWidth === 0 || video.videoHeight === 0) {
+        return;
+      }
+
       try {
-        const video = videoRef.current;
         const canvas = canvasRef.current;
 
-        // 设置 canvas 尺寸与视频一致
         if (canvas.width !== video.videoWidth || canvas.height !== video.videoHeight) {
-          canvas.width = video.videoWidth || 640;
-          canvas.height = video.videoHeight || 480;
+          canvas.width = video.videoWidth;
+          canvas.height = video.videoHeight;
         }
 
-        // 绘制当前帧
         const ctx = canvas.getContext('2d');
         if (!ctx) return;
 
         ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
 
-        // 转为 base64
-        const imageData = canvas.toDataURL('image/png');
+        const imageData = canvas.toDataURL('image/jpeg', 0.7);
         setCurrentImage(imageData);
         currentImageRef.current = imageData;
 
@@ -431,19 +483,36 @@ function App() {
           lastCaptureTime: timeStr
         }));
 
-        // 推送到视频流（不等待响应，避免阻塞）
+        // 推送到视频流
         if (isLoggedIn && config.is_registered && isOnline) {
-          invoke("upload_screenshot_v2", { imageData }).catch(e => {
-            console.error("Video push failed:", e);
-          });
+          invoke("upload_screenshot_v2", { imageData })
+            .then(() => { pushSuccessCount.current++; })
+            .catch(e => {
+              pushFailCount.current++;
+              if (captureFrameCount.current % 10 === 0) {
+                console.error("[VideoPush] Failed:", e);
+              }
+            });
         }
       } catch (e) {
-        console.error("Capture failed:", e);
+        console.error("[VideoPush] Camera capture failed:", e);
       }
-    } else {
-      // 截图模式（调用后端截屏）
+    } else if (captureMode === "screen") {
+      console.log("[VideoPush] Entering screen capture mode");
+      // 防止同时多次截图
+      if (isCapturingRef.current) {
+        console.log("[VideoPush] Screen capture already in progress, skipping frame");
+        return;
+      }
+
+      isCapturingRef.current = true;
+
       try {
+        console.log("[VideoPush] Starting screen capture...");
         const imageData = await invoke<string>("capture_screen");
+        console.log("[VideoPush] Screen captured successfully, size:", imageData?.length);
+        console.log("[VideoPush] Image data prefix:", imageData?.substring(0, 50));
+
         setCurrentImage(imageData);
         currentImageRef.current = imageData;
 
@@ -454,14 +523,21 @@ function App() {
           lastCaptureTime: timeStr
         }));
 
-        // 推送到视频流（不等待响应，避免阻塞）
         if (isLoggedIn && config.is_registered && isOnline) {
-          invoke("upload_screenshot_v2", { imageData }).catch(e => {
-            console.error("Video push failed:", e);
-          });
+          invoke("upload_screenshot_v2", { imageData })
+            .then(() => {
+              pushSuccessCount.current++;
+              console.log("[VideoPush] Screen frame pushed successfully");
+            })
+            .catch(e => {
+              pushFailCount.current++;
+              console.error("[VideoPush] Failed:", e);
+            });
         }
       } catch (e) {
-        console.error("Screen capture failed:", e);
+        console.error("[VideoPush] Screen capture failed:", e);
+      } finally {
+        isCapturingRef.current = false;
       }
     }
   };
@@ -583,6 +659,14 @@ function App() {
   const switchCaptureMode = async (mode: string) => {
     if (!config) return;
 
+    console.log('[App] Switching capture mode to:', mode);
+
+    // 先更新 ref，确保 captureAndPushFrame 立即使用新模式
+    captureModeRef.current = mode as "camera" | "screen";
+
+    // 更新实际采集模式
+    setActualCaptureMode(mode as "camera" | "screen");
+
     const newConfig = { ...config, capture_mode: mode };
     setConfig(newConfig);
 
@@ -596,10 +680,12 @@ function App() {
     if (timerRef.current) {
       clearInterval(timerRef.current);
     }
+    // 根据模式设置不同的捕获间隔
+    const captureInterval = mode === "camera" ? 500 : 1000;
     captureFrame();
     timerRef.current = window.setInterval(() => {
       captureFrame();
-    }, config.interval * 1000);
+    }, captureInterval);
 
     // 根据模式初始化或停止摄像头
     if (mode === "camera" && hasCamera) {
@@ -609,9 +695,32 @@ function App() {
         streamRef.current.getTracks().forEach(track => track.stop());
         streamRef.current = null;
       }
+      // 重置截图锁
+      isCapturingRef.current = false;
     }
 
     setStatusMessage(mode === "camera" ? "已切换到摄像头模式" : "已切换到截图模式");
+  };
+
+  // 切换分辨率
+  const handleResolutionChange = async (resolution: string) => {
+    if (!config) return;
+
+    const newConfig = { ...config, camera_resolution: resolution };
+    setConfig(newConfig);
+
+    try {
+      await invoke("update_config", { newConfig });
+      setStatusMessage(`分辨率已切换到 ${resolution}`);
+
+      // 如果是摄像头模式，重新初始化摄像头
+      if (actualCaptureMode === "camera" && hasCamera) {
+        await initCamera();
+      }
+    } catch (e) {
+      console.error("Save resolution failed:", e);
+      setStatusMessage(`切换分辨率失败: ${e}`);
+    }
   };
 
   // 组件卸载时清理摄像头
@@ -717,264 +826,26 @@ function App() {
   }
 
   return (
-    <div className="app" style={{ padding: 0, background: '#0a0a0f', height: '100vh', display: 'flex', flexDirection: 'column' }}>
-      {/* 隐藏的 canvas 用于捕获帧 */}
+    <ThemeProvider>
+      {/* 隐藏的 video 和 canvas 用于捕获帧 */}
+      <video
+        ref={videoRef}
+        autoPlay
+        playsInline
+        muted
+        style={{ display: 'none' }}
+      />
       <canvas ref={canvasRef} style={{ display: 'none' }} />
-
-      {/* 顶部状态栏 - 简洁信息条 */}
-      <div style={{
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        padding: '12px 24px',
-        background: 'linear-gradient(90deg, #1a1a2e 0%, #16213e 100%)',
-        borderBottom: '1px solid rgba(255,255,255,0.1)',
-        color: 'white',
-        flexShrink: 0
-      }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: '24px' }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <span style={{ fontSize: '20px' }}>📷</span>
-            <span style={{ fontWeight: 600, fontSize: '16px' }}>智能黑板</span>
-          </div>
-          {config.account_username && (
-            <div style={{ display: 'flex', alignItems: 'center', gap: '6px', color: '#a0a0b0', fontSize: '14px' }}>
-              <span>👤</span>
-              <span>{config.account_username}</span>
-            </div>
-          )}
-          {config.dept_name && (
-            <div style={{ display: 'flex', alignItems: 'center', gap: '6px', color: '#a0a0b0', fontSize: '14px' }}>
-              <span>🏫</span>
-              <span>{config.dept_name}</span>
-            </div>
-          )}
-        </div>
-        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-          <span style={{
-            width: '8px',
-            height: '8px',
-            borderRadius: '50%',
-            background: isOnline ? '#4ade80' : '#ef4444',
-            boxShadow: isOnline ? '0 0 8px #4ade80' : '0 0 8px #ef4444'
-          }} />
-          <span style={{ fontSize: '14px', color: isOnline ? '#4ade80' : '#ef4444' }}>
-            {isOnline ? '在线' : '离线'}
-          </span>
-        </div>
-      </div>
-
-      {/* 错误提示 */}
-      {cameraError && (
-        <div style={{
-          padding: '12px 24px',
-          background: '#7f1d1d',
-          color: '#fecaca',
-          textAlign: 'center',
-          fontSize: '14px',
-          flexShrink: 0
-        }}>
-          {cameraError}
-        </div>
-      )}
-
-      {/* 主内容区 - 摄像头预览 */}
-      <div style={{
-        flex: 1,
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        padding: '16px',
-        overflow: 'hidden',
-        position: 'relative'
-      }}>
-        <div style={{
-          width: '100%',
-          height: '100%',
-          borderRadius: '12px',
-          overflow: 'hidden',
-          background: '#000',
-          boxShadow: '0 4px 24px rgba(0,0,0,0.5)',
-          position: 'relative'
-        }}>
-          {/* 摄像头预览 - 全屏大画面 */}
-          {config.capture_mode === "camera" && hasCamera && previewEnabled && !cameraError && (
-            <video
-              ref={videoRef}
-              autoPlay
-              playsInline
-              muted
-              style={{ width: '100%', height: '100%', objectFit: 'cover', background: '#000' }}
-            />
-          )}
-          {/* 屏幕截图显示 */}
-          {config.capture_mode === "screen" && currentImage && (
-            <img src={currentImage} alt="预览" style={{ width: '100%', height: '100%', objectFit: 'contain' }} />
-          )}
-          {/* 无画面时 */}
-          {(!previewEnabled || cameraError || !currentImage) && (
-            <div style={{
-              width: '100%',
-              height: '100%',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              flexDirection: 'column',
-              gap: '16px',
-              color: '#666'
-            }}>
-              <span style={{ fontSize: '64px', opacity: 0.5 }}>{cameraError ? '⚠️' : '📷'}</span>
-              <span style={{ fontSize: '18px' }}>{cameraError ? '摄像头异常' : '正在启动...'}</span>
-            </div>
-          )}
-
-          {/* 状态浮层 - 右上角 */}
-          {statusMessage && (
-            <div style={{
-              position: 'absolute',
-              top: '16px',
-              right: '16px',
-              padding: '8px 16px',
-              background: 'rgba(0,0,0,0.7)',
-              backdropFilter: 'blur(8px)',
-              borderRadius: '8px',
-              color: '#fff',
-              fontSize: '13px',
-              border: '1px solid rgba(255,255,255,0.1)'
-            }}>
-              {statusMessage}
-            </div>
-          )}
-
-          {/* 分辨率选择器 - 左上角 */}
-          {config.capture_mode === "camera" && hasCamera && (
-            <div style={{
-              position: 'absolute',
-              top: '16px',
-              left: '16px',
-              display: 'flex',
-              gap: '8px'
-            }}>
-              <select
-                value={config.camera_resolution}
-                onChange={async (e) => {
-                  const newRes = e.target.value;
-                  setConfig({ ...config, camera_resolution: newRes });
-                  await invoke("update_config", {
-                    newConfig: { ...config, camera_resolution: newRes }
-                  });
-                  initCamera();
-                }}
-                style={{
-                  padding: '8px 12px',
-                  background: 'rgba(0,0,0,0.6)',
-                  backdropFilter: 'blur(8px)',
-                  border: '1px solid rgba(255,255,255,0.2)',
-                  borderRadius: '8px',
-                  color: '#fff',
-                  fontSize: '13px',
-                  cursor: 'pointer'
-                }}
-              >
-                <option value="480p" style={{ background: '#1a1a2e' }}>480p</option>
-                <option value="720p" style={{ background: '#1a1a2e' }}>720p</option>
-                <option value="1080p" style={{ background: '#1a1a2e' }}>1080p</option>
-              </select>
-            </div>
-          )}
-        </div>
-      </div>
-
-      {/* 底部信息栏 */}
-      <div style={{
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        padding: '16px 24px',
-        background: 'linear-gradient(90deg, #1a1a2e 0%, #16213e 100%)',
-        borderTop: '1px solid rgba(255,255,255,0.1)',
-        color: 'white',
-        flexShrink: 0
-      }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: '32px' }}>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
-            <span style={{ fontSize: '11px', color: '#888' }}>设备</span>
-            <span style={{ fontSize: '14px', fontWeight: 500 }}>{config.device_name || '未命名设备'}</span>
-          </div>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
-            <span style={{ fontSize: '11px', color: '#888' }}>截图间隔</span>
-            <span style={{ fontSize: '14px', fontWeight: 500 }}>{config.interval} 秒</span>
-          </div>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
-            <span style={{ fontSize: '11px', color: '#888' }}>今日截图</span>
-            <span style={{ fontSize: '14px', fontWeight: 500, color: '#4ade80' }}>{stats.todayCount} 张</span>
-          </div>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
-            <span style={{ fontSize: '11px', color: '#888' }}>最后截图</span>
-            <span style={{ fontSize: '14px', fontWeight: 500 }}>{stats.lastCaptureTime || '--:--:--'}</span>
-          </div>
-        </div>
-
-        <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
-          <button
-            onClick={() => switchCaptureMode(config.capture_mode === "camera" ? "screen" : "camera")}
-            style={{
-              padding: '10px 20px',
-              background: 'rgba(255,255,255,0.1)',
-              border: '1px solid rgba(255,255,255,0.2)',
-              borderRadius: '8px',
-              color: '#fff',
-              fontSize: '14px',
-              cursor: 'pointer',
-              transition: 'all 0.2s',
-              display: 'flex',
-              alignItems: 'center',
-              gap: '6px'
-            }}
-            onMouseEnter={(e) => e.currentTarget.style.background = 'rgba(255,255,255,0.15)'}
-            onMouseLeave={(e) => e.currentTarget.style.background = 'rgba(255,255,255,0.1)'}
-          >
-            {config.capture_mode === "camera" ? '📷 切截图' : '🎥 切摄像头'}
-          </button>
-          <button
-            onClick={captureFrame}
-            style={{
-              padding: '10px 20px',
-              background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
-              border: 'none',
-              borderRadius: '8px',
-              color: '#fff',
-              fontSize: '14px',
-              cursor: 'pointer',
-              transition: 'all 0.2s',
-              display: 'flex',
-              alignItems: 'center',
-              gap: '6px'
-            }}
-            onMouseEnter={(e) => e.currentTarget.style.transform = 'translateY(-2px)'}
-            onMouseLeave={(e) => e.currentTarget.style.transform = 'translateY(0)'}
-          >
-            📸 手动截图
-          </button>
-          <button
-            onClick={() => setShowSettings(true)}
-            style={{
-              padding: '10px 20px',
-              background: 'rgba(255,255,255,0.1)',
-              border: '1px solid rgba(255,255,255,0.2)',
-              borderRadius: '8px',
-              color: '#fff',
-              fontSize: '14px',
-              cursor: 'pointer',
-              transition: 'all 0.2s'
-            }}
-            onMouseEnter={(e) => e.currentTarget.style.background = 'rgba(255,255,255,0.15)'}
-            onMouseLeave={(e) => e.currentTarget.style.background = 'rgba(255,255,255,0.1)'}
-          >
-            ⚙️ 设置
-          </button>
-        </div>
-      </div>
+      <Dashboard
+        config={config}
+        hasCamera={hasCamera}
+        actualCaptureMode={actualCaptureMode}
+        currentImage={currentImage}
+        onToggleMode={() => switchCaptureMode(actualCaptureMode === "camera" ? "screen" : "camera")}
+        onSettingsClick={() => setShowSettings(true)}
+        onLogout={() => setIsLoggedIn(false)}
+        onResolutionChange={handleResolutionChange}
+      />
 
       {/* 设置弹窗 */}
       {showSettings && (
@@ -1118,7 +989,7 @@ function App() {
           </div>
         </div>
       )}
-    </div>
+    </ThemeProvider>
   );
 }
 

--- a/src/DeviceSetupNative.tsx
+++ b/src/DeviceSetupNative.tsx
@@ -1,4 +1,3 @@
-import { invoke } from "@tauri-apps/api/core";
 
 // 设备类型名称
 const deviceTypeMap: Record<number, string> = {

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,0 +1,415 @@
+import { useState, useEffect, useRef } from 'react';
+import { VideoPreview } from './VideoPreview';
+import { SoftwareUsageList } from './SoftwareUsageList';
+import { ThemeToggle } from './ThemeToggle';
+import { invoke } from '@tauri-apps/api/core';
+import {
+  Camera,
+  Settings,
+  LogOut,
+  RefreshCw,
+  Monitor,
+  Clock,
+  Wifi,
+  ChevronRight,
+  HardDrive,
+  Activity,
+  Check
+} from 'lucide-react';
+
+interface DashboardProps {
+  config: {
+    device_name: string;
+    capture_mode: string;
+    camera_resolution: string;
+    interval: number;
+    account_username?: string;
+    dept_name?: string;
+    class_name?: string;
+    school_class_id?: number;
+    device_code?: string;
+    device_type?: string;
+    is_registered: boolean;
+    api_url: string;
+  };
+  hasCamera: boolean;
+  actualCaptureMode: 'camera' | 'screen';
+  currentImage: string | null;
+  onToggleMode: () => void;
+  onSettingsClick: () => void;
+  onLogout: () => void;
+  onResolutionChange?: (resolution: string) => void;
+}
+
+interface SoftwareUsage {
+  id: string;
+  processName: string;
+  windowTitle: string;
+  isActive: boolean;
+  durationSecs: number;
+  lastActiveTime: string;
+}
+
+export function Dashboard({
+  config,
+  hasCamera,
+  actualCaptureMode,
+  currentImage,
+  onToggleMode,
+  onSettingsClick,
+  onLogout,
+  onResolutionChange,
+}: DashboardProps) {
+  const [showResolutionMenu, setShowResolutionMenu] = useState(false);
+  const [softwareUsages, setSoftwareUsages] = useState<SoftwareUsage[]>([]);
+  const [uptime, setUptime] = useState('计算中...');
+  const [currentTime, setCurrentTime] = useState(new Date());
+
+  // 调试日志
+  useEffect(() => {
+    console.log('[Dashboard] currentImage changed:', currentImage ? `length=${currentImage.length}` : 'null');
+  }, [currentImage]);
+
+  useEffect(() => {
+    console.log('[Dashboard] actualCaptureMode:', actualCaptureMode);
+  }, [actualCaptureMode]);
+
+  // 更新当前时间
+  useEffect(() => {
+    const timer = setInterval(() => setCurrentTime(new Date()), 1000);
+    return () => clearInterval(timer);
+  }, []);
+
+  // 计算运行时长
+  useEffect(() => {
+    const bootTime = performance.timing?.navigationStart || Date.now();
+
+    const updateUptime = () => {
+      const now = Date.now();
+      const diff = now - bootTime;
+      const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+      const hours = Math.floor((diff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+      const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
+
+      if (days > 0) {
+        setUptime(`${days}天${hours}小时${minutes}分钟`);
+      } else if (hours > 0) {
+        setUptime(`${hours}小时${minutes}分钟`);
+      } else {
+        setUptime(`${minutes}分钟`);
+      }
+    };
+
+    updateUptime();
+    const interval = setInterval(updateUptime, 60000);
+    return () => clearInterval(interval);
+  }, []);
+
+  // 屏幕截图现在由 App.tsx 中的 captureAndPushFrame 处理
+  // 这里只接收 currentImage prop 并传递给 VideoPreview
+  useEffect(() => {
+    setCurrentImageProp(currentImage);
+  }, [currentImage]);
+
+  const [currentImageProp, setCurrentImageProp] = useState<string | null>(currentImage);
+
+  // 定期刷新软件使用数据 - 改为60秒一次，减少频繁请求
+  const lastFetchTime = useRef<number>(0);
+  const isFetching = useRef<boolean>(false);
+
+  useEffect(() => {
+    const fetchSoftwareUsages = async () => {
+      // 防止重复请求
+      if (isFetching.current) return;
+
+      const now = Date.now();
+      // 节流：至少间隔60秒
+      if (now - lastFetchTime.current < 60000) return;
+
+      isFetching.current = true;
+      try {
+        const usages = await invoke<SoftwareUsage[]>('get_software_usages');
+        setSoftwareUsages(usages || []);
+        lastFetchTime.current = Date.now();
+      } catch (e) {
+        console.error('获取软件使用数据失败:', e);
+      } finally {
+        isFetching.current = false;
+      }
+    };
+
+    // 只在页面可见时获取
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        fetchSoftwareUsages();
+      }
+    };
+
+    fetchSoftwareUsages();
+    const interval = setInterval(fetchSoftwareUsages, 60000);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      clearInterval(interval);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, []);
+
+  const handleRefresh = async () => {
+    try {
+      const usages = await invoke<SoftwareUsage[]>('get_software_usages');
+      setSoftwareUsages(usages || []);
+      lastFetchTime.current = Date.now();
+    } catch (e) {
+      console.error('刷新失败:', e);
+    }
+  };
+
+  const isOnline = true;
+
+  const resolutions = [
+    { value: '480p', label: '480p', desc: '640x360' },
+    { value: '720p', label: '720p', desc: '1280x720' },
+    { value: '1080p', label: '1080p', desc: '1920x1080' },
+  ];
+
+  const handleResolutionChange = async (resolution: string) => {
+    if (onResolutionChange) {
+      await onResolutionChange(resolution);
+    }
+    setShowResolutionMenu(false);
+  };
+
+  return (
+    <div className="min-h-screen bg-slate-950 flex">
+      {/* 左侧边栏 - 设备信息 */}
+      <aside className="w-72 bg-slate-900/80 backdrop-blur-xl border-r border-slate-800 flex flex-col">
+        {/* Logo & Title */}
+        <div className="p-6 border-b border-slate-800">
+          <div className="flex items-center gap-3">
+            <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-blue-500 to-purple-600 flex items-center justify-center shadow-lg shadow-blue-500/20">
+              <Camera className="w-6 h-6 text-white" />
+            </div>
+            <div>
+              <h1 className="text-lg font-bold text-slate-100">设备监控</h1>
+              <p className="text-xs text-slate-400">智能黑板系统</p>
+            </div>
+          </div>
+        </div>
+
+        {/* 设备信息卡片 */}
+        <div className="flex-1 p-6 space-y-6 overflow-y-auto">
+          {/* 设备状态概览 */}
+          <div className="bg-gradient-to-br from-blue-500/10 to-purple-500/10 rounded-2xl p-5 border border-blue-500/20">
+            <div className="flex items-center gap-2 mb-4">
+              <div className={`w-3 h-3 rounded-full ${isOnline ? 'bg-emerald-400 animate-pulse' : 'bg-rose-400'}`} />
+              <span className="text-sm font-medium text-slate-300">
+                {isOnline ? '设备在线' : '设备离线'}
+              </span>
+            </div>
+            <h3 className="text-xl font-bold text-slate-100 mb-1">
+              {config.device_name || '未命名设备'}
+            </h3>
+            <p className="text-sm text-slate-400">
+              {config.dept_name || '未设置部门'}
+            </p>
+            {config.class_name && (
+              <p className="text-sm text-slate-400 mt-1">
+                <span className="text-slate-500">班级:</span> {config.class_name}
+              </p>
+            )}
+          </div>
+
+          {/* 信息列表 */}
+          <div className="space-y-4">
+            {/* 运行时长 */}
+            <div className="group">
+              <label className="text-xs font-medium text-slate-500 uppercase tracking-wider mb-2 block">
+                运行时长
+              </label>
+              <div className="flex items-center gap-3 p-3 bg-slate-800/50 rounded-xl border border-slate-700/50 group-hover:border-slate-600/50 transition-colors">
+                <div className="w-10 h-10 rounded-lg bg-amber-500/10 flex items-center justify-center">
+                  <Clock className="w-5 h-5 text-amber-400" />
+                </div>
+                <div>
+                  <p className="text-slate-100 font-medium">{uptime}</p>
+                  <p className="text-xs text-slate-500">自开机以来</p>
+                </div>
+              </div>
+            </div>
+
+            {/* 当前模式 */}
+            <div className="group">
+              <label className="text-xs font-medium text-slate-500 uppercase tracking-wider mb-2 block">
+                采集模式
+              </label>
+              <div className="flex items-center gap-3 p-3 bg-slate-800/50 rounded-xl border border-slate-700/50 group-hover:border-slate-600/50 transition-colors">
+                <div className="w-10 h-10 rounded-lg bg-blue-500/10 flex items-center justify-center">
+                  {actualCaptureMode === 'camera' ? (
+                    <Camera className="w-5 h-5 text-blue-400" />
+                  ) : (
+                    <Monitor className="w-5 h-5 text-blue-400" />
+                  )}
+                </div>
+                <div className="flex-1">
+                  <p className="text-slate-100 font-medium">
+                    {actualCaptureMode === 'camera' ? '摄像头模式' : '屏幕截图模式'}
+                  </p>
+                  <p className="text-xs text-slate-500">
+                    {hasCamera ? '摄像头可用' : '使用屏幕截图'}
+                  </p>
+                </div>
+                <button
+                  onClick={onToggleMode}
+                  className="p-2 rounded-lg hover:bg-slate-700/50 text-slate-400 hover:text-slate-200 transition-colors"
+                  title="切换模式"
+                >
+                  <RefreshCw className="w-4 h-4" />
+                </button>
+              </div>
+            </div>
+
+            {/* 分辨率 */}
+            <div className="group relative">
+              <label className="text-xs font-medium text-slate-500 uppercase tracking-wider mb-2 block">
+                分辨率设置
+              </label>
+              <button
+                onClick={() => setShowResolutionMenu(!showResolutionMenu)}
+                className="w-full flex items-center gap-3 p-3 bg-slate-800/50 rounded-xl border border-slate-700/50 hover:border-slate-600/50 transition-colors text-left"
+              >
+                <div className="w-10 h-10 rounded-lg bg-purple-500/10 flex items-center justify-center">
+                  <Activity className="w-5 h-5 text-purple-400" />
+                </div>
+                <div className="flex-1">
+                  <p className="text-slate-100 font-medium">{config.camera_resolution || '1080p'}</p>
+                  <p className="text-xs text-slate-500">点击切换分辨率</p>
+                </div>
+                <ChevronRight className={`w-4 h-4 text-slate-500 transition-transform ${showResolutionMenu ? 'rotate-90' : ''}`} />
+              </button>
+
+              {/* 分辨率下拉菜单 */}
+              {showResolutionMenu && (
+                <div className="absolute z-50 w-full mt-2 bg-slate-800 rounded-xl border border-slate-700 shadow-xl overflow-hidden">
+                  {resolutions.map((res) => (
+                    <button
+                      key={res.value}
+                      onClick={() => handleResolutionChange(res.value)}
+                      className={`w-full flex items-center justify-between px-4 py-3 text-left hover:bg-slate-700/50 transition-colors ${
+                        config.camera_resolution === res.value ? 'bg-purple-500/10' : ''
+                      }`}
+                    >
+                      <div>
+                        <p className={`font-medium ${config.camera_resolution === res.value ? 'text-purple-400' : 'text-slate-200'}`}>
+                          {res.label}
+                        </p>
+                        <p className="text-xs text-slate-500">{res.desc}</p>
+                      </div>
+                      {config.camera_resolution === res.value && (
+                        <Check className="w-4 h-4 text-purple-400" />
+                      )}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* 存储位置 */}
+            <div className="group">
+              <label className="text-xs font-medium text-slate-500 uppercase tracking-wider mb-2 block">
+                存储位置
+              </label>
+              <div className="flex items-center gap-3 p-3 bg-slate-800/50 rounded-xl border border-slate-700/50">
+                <div className="w-10 h-10 rounded-lg bg-emerald-500/10 flex items-center justify-center">
+                  <HardDrive className="w-5 h-5 text-emerald-400" />
+                </div>
+                <div>
+                  <p className="text-slate-100 font-medium">本地存储</p>
+                  <p className="text-xs text-slate-500">已启用自动备份</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* 底部操作区 */}
+        <div className="p-6 border-t border-slate-800 space-y-3">
+          <button
+            onClick={onSettingsClick}
+            className="w-full flex items-center justify-between px-4 py-3 bg-blue-500/10 hover:bg-blue-500/20
+                       text-blue-400 rounded-xl border border-blue-500/20 transition-all duration-200
+                       hover:shadow-lg hover:shadow-blue-500/10"
+          >
+            <div className="flex items-center gap-3">
+              <Settings className="w-5 h-5" />
+              <span className="font-medium">设置</span>
+            </div>
+            <ChevronRight className="w-4 h-4" />
+          </button>
+
+          <button
+            onClick={onLogout}
+            className="w-full flex items-center justify-between px-4 py-3 bg-rose-500/10 hover:bg-rose-500/20
+                       text-rose-400 rounded-xl border border-rose-500/20 transition-all duration-200"
+          >
+            <div className="flex items-center gap-3">
+              <LogOut className="w-5 h-5" />
+              <span className="font-medium">退出登录</span>
+            </div>
+            <ChevronRight className="w-4 h-4" />
+          </button>
+
+          <div className="flex items-center justify-between pt-2">
+            <span className="text-xs text-slate-500">
+              {currentTime.toLocaleTimeString()}
+            </span>
+            <ThemeToggle />
+          </div>
+        </div>
+      </aside>
+
+      {/* 右侧主内容区 */}
+      <main className="flex-1 flex flex-col min-w-0">
+        {/* 顶部标题栏 */}
+        <header className="h-16 bg-slate-900/50 backdrop-blur-xl border-b border-slate-800 flex items-center justify-between px-6">
+          <div className="flex items-center gap-4">
+            <h2 className="text-lg font-semibold text-slate-100">实时监控</h2>
+            <span className="text-sm text-slate-500">
+              {config.account_username}
+            </span>
+          </div>
+
+          <div className="flex items-center gap-3">
+            <button
+              onClick={handleRefresh}
+              className="flex items-center gap-2 px-4 py-2 rounded-lg bg-slate-800/50 hover:bg-slate-700/50
+                         text-slate-300 hover:text-slate-100 border border-slate-700/50 transition-all duration-200"
+            >
+              <RefreshCw className="w-4 h-4" />
+              <span className="text-sm font-medium">刷新软件列表</span>
+            </button>
+          </div>
+        </header>
+
+        {/* 主内容 */}
+        <div className="flex-1 p-6 overflow-auto">
+          <div className="max-w-6xl mx-auto space-y-6">
+            {/* 视频预览区域 - 大尺寸 */}
+            <div className="relative rounded-2xl overflow-hidden border border-slate-700/50 shadow-2xl bg-slate-900"
+                 style={{ height: '480px' }}>
+              <VideoPreview
+                hasCamera={hasCamera}
+                actualCaptureMode={actualCaptureMode}
+                currentImage={currentImageProp}
+                onToggleMode={onToggleMode}
+              />
+            </div>
+
+            {/* 软件使用列表 */}
+            <SoftwareUsageList usages={softwareUsages} defaultShowCount={6} />
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/components/DeviceInfoCard.tsx
+++ b/src/components/DeviceInfoCard.tsx
@@ -1,0 +1,97 @@
+import { useState, useEffect } from 'react';
+import { Monitor, Clock, Wifi, Settings } from 'lucide-react';
+
+interface DeviceInfoCardProps {
+  deviceName: string;
+  isOnline?: boolean;
+  onSettingsClick?: () => void;
+}
+
+export function DeviceInfoCard({ deviceName, isOnline = true, onSettingsClick }: DeviceInfoCardProps) {
+  const [uptime, setUptime] = useState('计算中...');
+
+  useEffect(() => {
+    // 获取系统启动时间（这里使用页面加载时间作为近似）
+    const bootTime = performance.timing?.navigationStart || Date.now();
+
+    const updateUptime = () => {
+      const now = Date.now();
+      const diff = now - bootTime;
+
+      const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+      const hours = Math.floor((diff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+      const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
+
+      if (days > 0) {
+        setUptime(`${days}天${hours}小时${minutes}分钟`);
+      } else if (hours > 0) {
+        setUptime(`${hours}小时${minutes}分钟`);
+      } else {
+        setUptime(`${minutes}分钟`);
+      }
+    };
+
+    updateUptime();
+    const interval = setInterval(updateUptime, 60000); // 每分钟更新
+
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div className="bg-slate-800/50 backdrop-blur-xl rounded-2xl border border-slate-700/50 shadow-xl p-6">
+      <div className="flex items-center gap-2 mb-5">
+        <Monitor className="w-5 h-5 text-blue-400" />
+        <h3 className="text-lg font-semibold text-slate-100">设备信息</h3>
+      </div>
+
+      <div className="space-y-5">
+        {/* 设备名称 */}
+        <div>
+          <label className="text-xs font-medium text-slate-400 uppercase tracking-wider mb-2 block">
+            设备名称
+          </label>
+          <div className="flex items-center gap-3 px-4 py-3 bg-slate-900/60 rounded-xl border border-slate-700/50">
+            <Monitor className="w-5 h-5 text-blue-400" />
+            <span className="text-slate-100 font-medium">{deviceName || '未命名设备'}</span>
+          </div>
+        </div>
+
+        {/* 开机时间 */}
+        <div>
+          <label className="text-xs font-medium text-slate-400 uppercase tracking-wider mb-2 block">
+            运行时长
+          </label>
+          <div className="flex items-center gap-3 px-4 py-3 bg-slate-900/60 rounded-xl border border-slate-700/50">
+            <Clock className="w-5 h-5 text-amber-400" />
+            <span className="text-slate-100 font-medium">{uptime}</span>
+          </div>
+        </div>
+
+        {/* 设备状态 */}
+        <div>
+          <label className="text-xs font-medium text-slate-400 uppercase tracking-wider mb-2 block">
+            设备状态
+          </label>
+          <div className="flex items-center gap-3 px-4 py-3 bg-slate-900/60 rounded-xl border border-slate-700/50">
+            <Wifi className={`w-5 h-5 ${isOnline ? 'text-emerald-400' : 'text-rose-400'}`} />
+            <div className="flex items-center gap-2">
+              <span className={`w-2.5 h-2.5 rounded-full ${isOnline ? 'bg-emerald-400 animate-pulse' : 'bg-rose-400'}`} />
+              <span className="text-slate-100 font-medium">{isOnline ? '在线' : '离线'}</span>
+            </div>
+          </div>
+        </div>
+
+        {/* 设置按钮 */}
+        <button
+          onClick={onSettingsClick}
+          className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-blue-500/20 hover:bg-blue-500/30
+                     text-blue-400 rounded-xl border border-blue-500/30 transition-all duration-200
+                     hover:shadow-lg hover:shadow-blue-500/10"
+        >
+          <Settings className="w-5 h-5" />
+          <span className="font-medium">设置</span>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SoftwareUsageList.tsx
+++ b/src/components/SoftwareUsageList.tsx
@@ -1,0 +1,209 @@
+import { useState, useMemo, useCallback } from 'react';
+import { Smartphone, ChevronDown, ChevronUp, Clock } from 'lucide-react';
+
+interface SoftwareUsage {
+  id: string;
+  processName: string;
+  windowTitle: string;
+  isActive: boolean;
+  durationSecs: number;
+  lastActiveTime: string;
+}
+
+interface SoftwareUsageListProps {
+  usages: SoftwareUsage[];
+  defaultShowCount?: number;
+}
+
+// 软件图标映射
+const softwareIcons: Record<string, string> = {
+  'chrome.exe': '🌐',
+  'firefox.exe': '🦊',
+  'edge.exe': '🌊',
+  'wps.exe': '📝',
+  'word.exe': '📄',
+  'excel.exe': '📊',
+  'powerpnt.exe': '📽️',
+  'wechat.exe': '💬',
+  'qq.exe': '🐧',
+  'dingtalk.exe': '🔔',
+  'default': '📱'
+};
+
+function getSoftwareIcon(processName: string): string {
+  const lowerName = processName.toLowerCase();
+  return softwareIcons[lowerName] || softwareIcons['default'];
+}
+
+function formatDuration(seconds: number): string {
+  if (seconds < 60) return `${seconds}秒`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}分钟`;
+  const hours = Math.floor(seconds / 3600);
+  const mins = Math.floor((seconds % 3600) / 60);
+  return mins > 0 ? `${hours}小时${mins}分钟` : `${hours}小时`;
+}
+
+function formatTimeAgo(timeStr: string): string {
+  // 处理空值或无效值
+  if (!timeStr || timeStr === 'null' || timeStr === 'undefined') {
+    return '未知';
+  }
+
+  const date = new Date(timeStr);
+
+  // 检查是否为有效日期
+  if (isNaN(date.getTime())) {
+    return '未知';
+  }
+
+  const now = new Date();
+  const diff = Math.floor((now.getTime() - date.getTime()) / 1000);
+
+  // 处理未来时间或无效差值
+  if (diff < 0) return '刚刚';
+  if (isNaN(diff)) return '未知';
+
+  if (diff < 60) return '刚刚';
+  if (diff < 3600) return `${Math.floor(diff / 60)}分钟前`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}小时前`;
+  return `${Math.floor(diff / 86400)}天前`;
+}
+
+export function SoftwareUsageList({ usages, defaultShowCount = 6 }: SoftwareUsageListProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  // 使用 useMemo 缓存数据，避免重复计算
+  // 限制最大显示数量，防止展开过多导致卡顿
+  const MAX_EXPANDED_COUNT = 20;
+
+  const { displayedUsages, hasMore, totalCount } = useMemo(() => {
+    const hasMoreItems = usages.length > defaultShowCount;
+    const displayed = isExpanded
+      ? usages.slice(0, MAX_EXPANDED_COUNT)
+      : usages.slice(0, defaultShowCount);
+    return {
+      displayedUsages: displayed,
+      hasMore: hasMoreItems || usages.length > MAX_EXPANDED_COUNT,
+      totalCount: usages.length
+    };
+  }, [usages, defaultShowCount, isExpanded]);
+
+  // 使用 useCallback 避免重复创建函数
+  const toggleExpanded = useCallback(() => {
+    setIsExpanded(prev => !prev);
+  }, []);
+
+  const expandOnly = useCallback(() => {
+    setIsExpanded(true);
+  }, []);
+
+  return (
+    <div className="bg-slate-800/50 backdrop-blur-xl rounded-2xl border border-slate-700/50 shadow-xl overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center justify-between px-6 py-4 border-b border-slate-700/50">
+        <div className="flex items-center gap-2">
+          <Smartphone className="w-5 h-5 text-purple-400" />
+          <h3 className="text-lg font-semibold text-slate-100">
+            当前运行软件
+            <span className="ml-2 text-sm font-normal text-slate-400">({totalCount})</span>
+          </h3>
+        </div>
+        {hasMore && (
+          <button
+            onClick={toggleExpanded}
+            className="flex items-center gap-1 px-3 py-1.5 text-sm text-slate-400 hover:text-slate-200
+                       bg-slate-700/50 hover:bg-slate-700 rounded-lg transition-all duration-200"
+            type="button"
+          >
+            {isExpanded ? (
+              <>
+                <span>收起</span>
+                <ChevronUp className="w-4 h-4" />
+              </>
+            ) : (
+              <>
+                <span>展开</span>
+                <ChevronDown className="w-4 h-4" />
+              </>
+            )}
+          </button>
+        )}
+      </div>
+
+      {/* Software List */}
+      <div className="divide-y divide-slate-700/30 max-h-[320px] overflow-y-auto scrollbar-thin scrollbar-thumb-slate-600 scrollbar-track-transparent">
+        {displayedUsages.length === 0 ? (
+          <div className="px-6 py-8 text-center text-slate-500">
+            <Smartphone className="w-12 h-12 mx-auto mb-3 opacity-30" />
+            <p className="text-sm">暂无软件使用记录</p>
+          </div>
+        ) : (
+          displayedUsages.map((usage, index) => (
+            <div
+              key={`${usage.id}-${index}`}
+              className={`flex items-center gap-4 px-6 py-4 ${
+                usage.isActive ? 'bg-emerald-500/5' : 'hover:bg-slate-700/20'
+              }`}
+              style={{ contentVisibility: 'auto' }}
+            >
+              {/* Status Indicator */}
+              <div className="relative flex-shrink-0">
+                <span className="text-2xl">{getSoftwareIcon(usage.processName)}</span>
+                {usage.isActive && (
+                  <span className="absolute -bottom-0.5 -right-0.5 w-3 h-3 bg-emerald-400 rounded-full border-2 border-slate-800" />
+                )}
+              </div>
+
+              {/* Software Info */}
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="font-medium text-slate-100 truncate">
+                    {usage.processName.replace('.exe', '')}
+                  </span>
+                  {usage.isActive && (
+                    <span className="flex-shrink-0 px-2 py-0.5 text-xs font-medium text-emerald-400
+                                   bg-emerald-400/10 rounded-full border border-emerald-400/20">
+                      使用中
+                    </span>
+                  )}
+                </div>
+                <p className="text-sm text-slate-400 truncate mt-0.5">
+                  {usage.windowTitle || '无窗口标题'}
+                </p>
+              </div>
+
+              {/* Duration */}
+              <div className="flex-shrink-0 flex items-center gap-1.5 text-sm text-slate-400">
+                <Clock className="w-3.5 h-3.5" />
+                {usage.isActive ? (
+                  <span className="text-emerald-400">{formatDuration(usage.durationSecs)}</span>
+                ) : (
+                  <span>{formatTimeAgo(usage.lastActiveTime)}</span>
+                )}
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+
+      {/* Footer - Show More / Scroll Hint */}
+      {isExpanded && usages.length > 6 && (
+        <div className="px-6 py-2 text-center text-xs text-slate-500 border-t border-slate-700/30">
+          已显示 {Math.min(usages.length, MAX_EXPANDED_COUNT)} 个软件，可滚动查看
+        </div>
+      )}
+      {hasMore && !isExpanded && (
+        <button
+          onClick={expandOnly}
+          className="w-full flex items-center justify-center gap-2 px-6 py-3 text-sm text-slate-400
+                     hover:text-slate-200 hover:bg-slate-700/30 transition-all duration-200
+                     border-t border-slate-700/30"
+          type="button"
+        >
+          <span>展开查看更多</span>
+          <ChevronDown className="w-4 h-4" />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,41 @@
+import { Sun, Moon, Monitor } from 'lucide-react';
+import { useTheme } from '../contexts/ThemeContext';
+
+export function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+
+  const getIcon = () => {
+    switch (theme) {
+      case 'light':
+        return <Sun className="w-5 h-5" />;
+      case 'dark':
+        return <Moon className="w-5 h-5" />;
+      case 'system':
+        return <Monitor className="w-5 h-5" />;
+    }
+  };
+
+  const getLabel = () => {
+    switch (theme) {
+      case 'light':
+        return '浅色';
+      case 'dark':
+        return '深色';
+      case 'system':
+        return '跟随系统';
+    }
+  };
+
+  return (
+    <button
+      onClick={toggleTheme}
+      className="flex items-center gap-2 px-3 py-2 rounded-lg bg-slate-800/50 hover:bg-slate-700/50
+                 text-slate-300 hover:text-slate-100 border border-slate-700/50
+                 transition-all duration-200 backdrop-blur-sm"
+      title={`当前主题: ${getLabel()} (点击切换)`}
+    >
+      {getIcon()}
+      <span className="text-sm font-medium">{getLabel()}</span>
+    </button>
+  );
+}

--- a/src/components/VideoPreview.tsx
+++ b/src/components/VideoPreview.tsx
@@ -1,0 +1,179 @@
+import { useEffect, useRef, useState } from 'react';
+import { Camera, Monitor, RefreshCw } from 'lucide-react';
+
+interface VideoPreviewProps {
+  hasCamera: boolean;
+  actualCaptureMode: 'camera' | 'screen';
+  currentImage?: string | null;
+  onToggleMode?: () => void;
+}
+
+export function VideoPreview({ hasCamera, actualCaptureMode, currentImage, onToggleMode }: VideoPreviewProps) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+
+  // 调试日志
+  useEffect(() => {
+    console.log('[VideoPreview] currentImage:', currentImage ? `length=${currentImage.length}` : 'null');
+    console.log('[VideoPreview] actualCaptureMode:', actualCaptureMode);
+  }, [currentImage, actualCaptureMode]);
+
+  useEffect(() => {
+    if (actualCaptureMode !== 'camera') {
+      setIsLoading(false);
+      setError(null);
+      return;
+    }
+
+    // 摄像头模式：初始化预览
+    const initPreview = async () => {
+      try {
+        setIsLoading(true);
+        setError(null);
+
+        // 检查是否有视频设备
+        const devices = await navigator.mediaDevices.enumerateDevices();
+        const videoDevices = devices.filter(d => d.kind === 'videoinput');
+
+        if (videoDevices.length === 0) {
+          setError('未检测到摄像头设备');
+          setIsLoading(false);
+          return;
+        }
+
+        // 获取摄像头流
+        const stream = await navigator.mediaDevices.getUserMedia({
+          video: {
+            width: { ideal: 1280 },
+            height: { ideal: 720 },
+            facingMode: 'user'
+          },
+          audio: false
+        });
+
+        streamRef.current = stream;
+
+        if (videoRef.current) {
+          videoRef.current.srcObject = stream;
+          await videoRef.current.play();
+        }
+
+        setIsLoading(false);
+      } catch (err) {
+        console.error('Camera preview error:', err);
+        const errorMsg = err instanceof Error ? err.message : String(err);
+        if (errorMsg.includes('Permission denied') || errorMsg.includes('NotAllowed')) {
+          setError('需要摄像头权限');
+        } else {
+          setError('摄像头启动失败');
+        }
+        setIsLoading(false);
+      }
+    };
+
+    // 延迟初始化，给主组件的捕获流让路
+    const timer = setTimeout(() => {
+      initPreview();
+    }, 100);
+
+    return () => {
+      clearTimeout(timer);
+      if (streamRef.current) {
+        streamRef.current.getTracks().forEach(track => track.stop());
+        streamRef.current = null;
+      }
+    };
+  }, [actualCaptureMode]);
+
+  const isCameraMode = actualCaptureMode === 'camera' && hasCamera && !error;
+
+  return (
+    <div className="relative w-full h-full bg-slate-900 rounded-2xl overflow-hidden border border-slate-700/50 shadow-2xl">
+      {/* Header */}
+      <div className="absolute top-0 left-0 right-0 z-10 flex items-center justify-between px-4 py-3 bg-gradient-to-b from-black/60 to-transparent">
+        <div className="flex items-center gap-2 text-white/90">
+          {isCameraMode ? (
+            <>
+              <Camera className="w-4 h-4" />
+              <span className="text-sm font-medium">摄像头画面</span>
+            </>
+          ) : (
+            <>
+              <Monitor className="w-4 h-4" />
+              <span className="text-sm font-medium">屏幕画面</span>
+            </>
+          )}
+        </div>
+
+        {onToggleMode && (
+          <button
+            onClick={onToggleMode}
+            className="p-2 rounded-lg bg-white/10 hover:bg-white/20 text-white/80 transition-all duration-200"
+            title="切换预览模式"
+          >
+            <RefreshCw className="w-4 h-4" />
+          </button>
+        )}
+      </div>
+
+      {/* Video/Screen Content */}
+      <div className="relative w-full h-full flex items-center justify-center">
+        {isCameraMode ? (
+          <video
+            ref={videoRef}
+            autoPlay
+            playsInline
+            muted
+            className="w-full h-full object-cover"
+          />
+        ) : currentImage ? (
+          <img
+            src={currentImage}
+            alt="屏幕截图"
+            className="w-full h-full object-contain"
+          />
+        ) : (
+          <div className="flex flex-col items-center justify-center text-slate-500">
+            <Monitor className="w-16 h-16 mb-4 opacity-50" />
+            <p className="text-sm">{hasCamera ? '屏幕预览模式' : '摄像头不可用，显示屏幕画面'}</p>
+            <p className="text-xs mt-2 opacity-60">正在获取屏幕截图...</p>
+          </div>
+        )}
+
+        {isLoading && (
+          <div className="absolute inset-0 flex items-center justify-center bg-slate-900/80">
+            <div className="flex items-center gap-3 text-white/70">
+              <div className="w-5 h-5 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+              <span className="text-sm">正在初始化摄像头...</span>
+            </div>
+          </div>
+        )}
+
+        {error && (
+          <div className="absolute inset-0 flex items-center justify-center bg-slate-900/90">
+            <div className="text-center">
+              <Camera className="w-12 h-12 mx-auto mb-3 text-slate-600" />
+              <p className="text-white/70 text-sm">{error}</p>
+              <p className="text-white/40 text-xs mt-2">已自动切换到屏幕预览模式</p>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Bottom Status Bar */}
+      <div className="absolute bottom-0 left-0 right-0 px-4 py-2 bg-gradient-to-t from-black/60 to-transparent">
+        <div className="flex items-center justify-between text-white/70 text-xs">
+          <div className="flex items-center gap-2">
+            <span className="flex items-center gap-1.5">
+              <span className={`w-2 h-2 rounded-full ${isCameraMode ? 'bg-emerald-400 animate-pulse' : 'bg-amber-400'}`} />
+              {isCameraMode ? '摄像头预览中' : '屏幕预览模式'}
+            </span>
+          </div>
+          <span>{isCameraMode ? '实时视频流' : '自动切换'}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,0 +1,75 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+type Theme = 'light' | 'dark' | 'system';
+
+interface ThemeContextType {
+  theme: Theme;
+  effectiveTheme: 'light' | 'dark';
+  setTheme: (theme: Theme) => void;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>(() => {
+    const saved = localStorage.getItem('theme');
+    return (saved as Theme) || 'system';
+  });
+
+  const [effectiveTheme, setEffectiveTheme] = useState<'light' | 'dark'>('dark');
+
+  useEffect(() => {
+    const updateEffectiveTheme = () => {
+      if (theme === 'system') {
+        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        setEffectiveTheme(prefersDark ? 'dark' : 'light');
+      } else {
+        setEffectiveTheme(theme);
+      }
+    };
+
+    updateEffectiveTheme();
+
+    if (theme === 'system') {
+      const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+      mediaQuery.addEventListener('change', updateEffectiveTheme);
+      return () => mediaQuery.removeEventListener('change', updateEffectiveTheme);
+    }
+  }, [theme]);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (effectiveTheme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+  }, [effectiveTheme]);
+
+  const setTheme = (newTheme: Theme) => {
+    setThemeState(newTheme);
+    localStorage.setItem('theme', newTheme);
+  };
+
+  const toggleTheme = () => {
+    const themes: Theme[] = ['light', 'dark', 'system'];
+    const currentIndex = themes.indexOf(theme);
+    const nextTheme = themes[(currentIndex + 1) % themes.length];
+    setTheme(nextTheme);
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, effectiveTheme, setTheme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -11,3 +11,26 @@
   font-weight: 500;
   border-left: 4px solid #c62828;
 }
+
+/* 自定义滚动条样式 */
+.scrollbar-thin {
+  scrollbar-width: thin;
+  scrollbar-color: #475569 transparent;
+}
+
+.scrollbar-thin::-webkit-scrollbar {
+  width: 6px;
+}
+
+.scrollbar-thin::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.scrollbar-thin::-webkit-scrollbar-thumb {
+  background-color: #475569;
+  border-radius: 3px;
+}
+
+.scrollbar-thin::-webkit-scrollbar-thumb:hover {
+  background-color: #64748b;
+}


### PR DESCRIPTION
## 问题描述

推送软件使用数据时，`deptId` 和 `classId` 放在请求体根级别，但服务端按 API 文档解析，期望这两个字段在 `session` 对象内部，导致数据库存储时 `dept_id` 和 `class_id` 为 null。

## 修复内容

### 1. 数据结构修复
- **批量推送** (`push_all_running_software`): 将 `deptId`/`classId` 从根级别移至每个 `SoftwareSessionPayload`
- **实时推送** (`push_software_realtime`): 将 `deptId`/`classId` 从根级别移至 `SessionPayload`

### 2. 字段验证
- 添加验证确保 `dept_id` 和 `class_id` 不为空
- 添加验证确保 ID 值不为 0，避免错误数据入库

### 3. 清理冗余字段
- 移除根级别多余的 `device_name`、`device_type`、`class_name` 字段

## 变更后的数据结构

```json
{
  "deviceCode": "DEVICE_xxx",
  "sessions": [{
    "id": "...",
    "processName": "...",
    "deptId": 362,
    "classId": 9
  }]
}
```

现在数据结构符合 API 文档要求。

## 测试

- [x] 批量推送数据结构验证
- [x] 实时推送数据结构验证
- [x] 字段缺失时返回明确错误信息